### PR TITLE
Add NFT bridge interface

### DIFF
--- a/cadence/contracts/bridge/FlowEVMBridge.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridge.cdc
@@ -9,6 +9,7 @@ import "EVM"
 import "BridgePermissions"
 import "ICrossVM"
 import "IEVMBridgeNFTMinter"
+import "IFlowEVMNFTBridge"
 import "CrossVMNFT"
 import "FlowEVMBridgeConfig"
 import "FlowEVMBridgeUtils"
@@ -25,7 +26,7 @@ import "FlowEVMBridgeTemplates"
 /// - FLIP #237: https://github.com/onflow/flips/pull/233
 ///
 access(all)
-contract FlowEVMBridge {
+contract FlowEVMBridge : IFlowEVMNFTBridge {
 
     /*************
         Events
@@ -322,6 +323,13 @@ contract FlowEVMBridge {
     /**************************
         Public Getters
     **************************/
+
+    /// Returns the EVM address associated with the provided type
+    ///
+    access(all)
+    view fun getAssociatedEVMAddress(with type: Type): EVM.EVMAddress? {
+        return FlowEVMBridgeConfig.getEVMAddressAssociated(with: type)
+    }
 
     /// Retrieves the bridge contract's COA EVMAddress
     ///

--- a/cadence/contracts/bridge/FlowEVMBridge.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridge.cdc
@@ -202,7 +202,7 @@ contract FlowEVMBridge : IFlowEVMNFTBridge {
                 gasLimit: 15000000,
                 value: 0.0
             )
-            assert(callResult.status == EVM.Status.successful, message: "Tranfer to bridge recipient failed")
+            assert(callResult.status == EVM.Status.successful, message: "Transfer to bridge recipient failed")
         }
     }
 

--- a/cadence/contracts/bridge/IFlowEVMNFTBridge.cdc
+++ b/cadence/contracts/bridge/IFlowEVMNFTBridge.cdc
@@ -5,6 +5,7 @@ import "EVM"
 
 import "FlowEVMBridgeConfig"
 import "FlowEVMBridgeUtils"
+import "CrossVMNFT"
 
 access(all) contract interface IFlowEVMNFTBridge {
     
@@ -67,7 +68,7 @@ access(all) contract interface IFlowEVMNFTBridge {
             emit BridgedNFTToEVM(
                 type: token.getType(),
                 id: token.id,
-                evmID: 0,
+                evmID: CrossVMNFT.getEVMID(from: &token as &{NonFungibleToken.NFT}) ?? UInt256(token.id),
                 to: FlowEVMBridgeUtils.getEVMAddressAsHexString(address: to),
                 evmContractAddress: FlowEVMBridgeUtils.getEVMAddressAsHexString(
                     address: self.getAssociatedEVMAddress(with: token.getType())

--- a/cadence/contracts/bridge/IFlowEVMNFTBridge.cdc
+++ b/cadence/contracts/bridge/IFlowEVMNFTBridge.cdc
@@ -1,0 +1,109 @@
+import "FungibleToken"
+import "NonFungibleToken"
+
+import "EVM"
+
+import "FlowEVMBridgeConfig"
+import "FlowEVMBridgeUtils"
+
+access(all) contract interface IFlowEVMNFTBridge {
+    
+    /*************
+        Events
+    **************/
+
+    /// Broadcasts an NFT was bridged from Cadence to EVM
+    access(all)
+    event BridgedNFTToEVM(
+        type: Type,
+        id: UInt64,
+        evmID: UInt256,
+        to: String,
+        evmContractAddress: String,
+        bridgeAddress: Address
+    )
+    /// Broadcasts an NFT was bridged from EVM to Cadence
+    access(all)
+    event BridgedNFTFromEVM(
+        type: Type,
+        id: UInt64,
+        evmID: UInt256,
+        caller: String,
+        evmContractAddress: String,
+        bridgeAddress: Address
+    )
+
+    /**************
+        Getters
+    ***************/
+
+    /// Returns the EVM address associated with the provided type
+    ///
+    access(all)
+    view fun getAssociatedEVMAddress(with type: Type): EVM.EVMAddress?
+
+    /********************************
+        Public Bridge Entrypoints
+    *********************************/
+
+    /// Public entrypoint to bridge NFTs from Cadence to EVM.
+    ///
+    /// @param token: The NFT to be bridged
+    /// @param to: The NFT recipient in FlowEVM
+    /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+    ///
+    access(all)
+    fun bridgeNFTToEVM(
+        token: @{NonFungibleToken.NFT},
+        to: EVM.EVMAddress,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+    ) {
+        pre {
+            emit BridgedNFTToEVM(
+                type: token.getType(),
+                id: token.id,
+                evmID: 0,
+                to: FlowEVMBridgeUtils.getEVMAddressAsHexString(address: to),
+                evmContractAddress: FlowEVMBridgeUtils.getEVMAddressAsHexString(
+                    address: self.getAssociatedEVMAddress(with: token.getType())
+                        ?? panic("Could not find EVM Contract address associated with provided NFT")
+                ), bridgeAddress: self.account.address
+            )
+        }
+    }
+
+    /// Public entrypoint to bridge NFTs from EVM to Cadence
+    ///
+    /// @param owner: The EVM address of the NFT owner. Current ownership and successful transfer (via 
+    ///     `protectedTransferCall`) is validated before the bridge request is executed.
+    /// @param calldata: Caller-provided approve() call, enabling contract COA to operate on NFT in EVM contract
+    /// @param id: The NFT ID to bridged
+    /// @param evmContractAddress: Address of the EVM address defining the NFT being bridged - also call target
+    /// @param feeProvider: A reference to a FungibleToken Provider from which the bridging fee is withdrawn in $FLOW
+    /// @param protectedTransferCall: A function that executes the transfer of the NFT from the named owner to the
+    ///     bridge's COA. This function is expected to return a Result indicating the status of the transfer call.
+    ///
+    /// @returns The bridged NFT
+    ///
+    access(all)
+    fun bridgeNFTFromEVM(
+        owner: EVM.EVMAddress,
+        type: Type,
+        id: UInt256,
+        feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider},
+        protectedTransferCall: fun (): EVM.Result
+    ): @{NonFungibleToken.NFT} {
+        post {
+            emit BridgedNFTFromEVM(
+                type: result.getType(),
+                id: result.id,
+                evmID: id,
+                caller: FlowEVMBridgeUtils.getEVMAddressAsHexString(address: owner),
+                evmContractAddress: FlowEVMBridgeUtils.getEVMAddressAsHexString(
+                    address: self.getAssociatedEVMAddress(with: result.getType())
+                        ?? panic("Could not find EVM Contract address associated with provided NFT")
+                ), bridgeAddress: self.account.address
+            )
+        }
+    }
+}

--- a/cadence/contracts/bridge/IFlowEVMNFTBridge.cdc
+++ b/cadence/contracts/bridge/IFlowEVMNFTBridge.cdc
@@ -42,6 +42,11 @@ access(all) contract interface IFlowEVMNFTBridge {
     access(all)
     view fun getAssociatedEVMAddress(with type: Type): EVM.EVMAddress?
 
+    /// Returns the EVM address of the bridge coordinating COA
+    ///
+    access(all)
+    view fun getBridgeCOAEVMAddress(): EVM.EVMAddress
+
     /********************************
         Public Bridge Entrypoints
     *********************************/

--- a/local/setup_emulator.2.sh
+++ b/local/setup_emulator.2.sh
@@ -1,6 +1,6 @@
 # Provided address is the address of the Factory contract deployed in the previous txn
 flow-c1 accounts add-contract ./cadence/contracts/bridge/FlowEVMBridgeUtils.cdc \
-    <REPLACE WITH `deployedContractAddress` VALUE WHEN FACTORY WAS DEPLOYED>
+    <REPLACE WITH DEPLOYED FACTORY EVM ADDRESS>
 
 flow-c1 accounts add-contract ./cadence/contracts/bridge/FlowEVMBridgeNFTEscrow.cdc
 flow-c1 accounts add-contract ./cadence/contracts/bridge/FlowEVMBridgeTemplates.cdc
@@ -10,11 +10,12 @@ flow-c1 transactions send ./cadence/transactions/bridge/admin/upsert_contract_co
 
 flow-c1 accounts add-contract ./cadence/contracts/bridge/IEVMBridgeNFTMinter.cdc
 
-# Deploy main bridge contract
-flow-c1 accounts add-contract ./cadence/contracts/bridge/FlowEVMBridge.cdc f8d6e0586b0a20c7
+# Deploy main bridge interface & contract
+flow-c1 accounts add-contract ./cadence/contracts/bridge/IFlowEVMNFTBridge.cdc
+flow-c1 accounts add-contract ./cadence/contracts/bridge/FlowEVMBridge.cdc
 
 # Deploy the bridge router directing calls from COAs to the dedicated bridge
-flow-c1 accounts add-contract ./cadence/contracts/bridge/EVMBridgeRouter.cdc f8d6e0586b0a20c7
+flow-c1 accounts add-contract ./cadence/contracts/bridge/EVMBridgeRouter.cdc 0xf8d6e0586b0a20c7 FlowEVMBridge
 
 # Create `example-nft` account 179b6b1cb6755e31 with private key 96dfbadf086daa187100a24b1fd2b709b702954bbd030a394148e11bcbb799ef
 flow-c1 accounts create --key "351e1310301a7374430f6077d7b1b679c9574f8e045234eac09568ceb15c4f5d937104b4c3180df1e416da20c9d58aac576ffc328a342198a5eae4a29a13c47a"


### PR DESCRIPTION
## Description

Introduces a Bridge interface (`IFlowEVMNFTBridge`) which is implemented in the main bridging contract (`FlowEVMBridge`). This enables central bridging events from any implementing contract identifying the asset bridged, the bridge address, and the recipient/requestor of the bridge request. This interface is then leveraged in `EVMBridgeRouter` which direct calls from `EVM.CadenceOwnedAccount`s to the named bridge contract. 

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 