### PR TITLE
Add type assertions when bridging assets

### DIFF
--- a/cadence/transactions/bridge/nft/bridge_nft_from_evm.cdc
+++ b/cadence/transactions/bridge/nft/bridge_nft_from_evm.cdc
@@ -92,6 +92,12 @@ transaction(nftIdentifier: String, id: UInt256) {
             id: id,
             feeProvider: &self.scopedProvider as auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
         )
+        // Ensure the bridged nft is the correct type
+        assert(
+            nft.getType() == self.nftType,
+            message: "Bridged nft type mismatch - requeswted: ".concat(self.nftType.identifier)
+                .concat(", received: ").concat(nft.getType().identifier)
+        )
         // Deposit the bridged NFT into the signer's collection
         self.collection.deposit(token: <-nft)
         // Destroy the ScopedFTProvider

--- a/cadence/transactions/bridge/nft/bridge_nft_to_any_cadence_address.cdc
+++ b/cadence/transactions/bridge/nft/bridge_nft_to_any_cadence_address.cdc
@@ -95,6 +95,12 @@ transaction(nftIdentifier: String, id: UInt256, recipient: Address) {
             id: id,
             feeProvider: &self.scopedProvider as auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
         )
+        // Ensure the bridged nft is the correct type
+        assert(
+            nft.getType() == self.nftType,
+            message: "Bridged nft type mismatch - requeswted: ".concat(self.nftType.identifier)
+                .concat(", received: ").concat(nft.getType().identifier)
+        )
         // Deposit the bridged NFT into the signer's collection
         self.receiver.deposit(token: <-nft)
         // Destroy the ScopedFTProvider

--- a/cadence/transactions/bridge/nft/bridge_nft_to_any_evm_address.cdc
+++ b/cadence/transactions/bridge/nft/bridge_nft_to_any_evm_address.cdc
@@ -86,6 +86,12 @@ transaction(nftIdentifier: String, id: UInt64, recipient: String) {
             )
     }
 
+    pre {
+        self.nft.getType().identifier == nftIdentifier:
+            "Attempting to send invalid nft type - requested: ".concat(nftIdentifier)
+            .concat(", sending: ").concat(self.nft.getType().identifier)
+    }
+
     execute {
         if self.requiresOnboarding {
             // Onboard the NFT to the bridge

--- a/cadence/transactions/bridge/nft/bridge_nft_to_evm.cdc
+++ b/cadence/transactions/bridge/nft/bridge_nft_to_evm.cdc
@@ -93,6 +93,12 @@ transaction(nftIdentifier: String, id: UInt64) {
             )
     }
 
+    pre {
+        self.nft.getType().identifier == nftIdentifier:
+            "Attempting to send invalid nft type - requested: ".concat(nftIdentifier)
+            .concat(", sending: ").concat(self.nft.getType().identifier)
+    }
+
     execute {
         if self.requiresOnboarding {
             // Onboard the NFT to the bridge

--- a/cadence/transactions/bridge/tokens/bridge_tokens_from_evm.cdc
+++ b/cadence/transactions/bridge/tokens/bridge_tokens_from_evm.cdc
@@ -102,6 +102,8 @@ transaction(vaultIdentifier: String, amount: UInt256) {
             amount: amount,
             feeProvider: &self.scopedProvider as auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
         )
+        // Ensure the bridged vault is the correct type
+        assert(vault.getType() == self.vaultType, message: "Bridged vault type mismatch")
         // Deposit the bridged token into the signer's vault
         self.receiver.deposit(from: <-vault)
         // Destroy the ScopedFTProvider

--- a/cadence/transactions/bridge/tokens/bridge_tokens_to_any_cadence_address.cdc
+++ b/cadence/transactions/bridge/tokens/bridge_tokens_to_any_cadence_address.cdc
@@ -105,6 +105,8 @@ transaction(vaultIdentifier: String, amount: UInt256, recipient: Address) {
             amount: amount,
             feeProvider: &self.scopedProvider as auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
         )
+        // Ensure the bridged vault is the correct type
+        assert(vault.getType() == self.vaultType, message: "Bridged vault type mismatch")
         // Deposit the bridged token into the signer's vault
         self.receiver.deposit(from: <-vault)
         // Destroy the ScopedFTProvider

--- a/cadence/transactions/bridge/tokens/bridge_tokens_to_any_evm_address.cdc
+++ b/cadence/transactions/bridge/tokens/bridge_tokens_to_any_evm_address.cdc
@@ -91,6 +91,9 @@ transaction(vaultIdentifier: String, amount: UFix64, recipient: String) {
     }
 
     pre {
+        self.sentVault.getType().identifier == vaultIdentifier:
+            "Attempting to send invalid vault type - requested: ".concat(vaultIdentifier)
+            .concat(", sending: ").concat(self.sentVault.getType().identifier)
         self.sentVault.balance == amount: "Amount to be transferred does not match the requested amount"
     }
 

--- a/cadence/transactions/bridge/tokens/bridge_tokens_to_evm.cdc
+++ b/cadence/transactions/bridge/tokens/bridge_tokens_to_evm.cdc
@@ -94,6 +94,12 @@ transaction(vaultIdentifier: String, amount: UFix64) {
             )
     }
 
+    pre {
+        self.sentVault.getType().identifier == vaultIdentifier:
+            "Attempting to send invalid vault type - requested: ".concat(vaultIdentifier)
+            .concat(", sending: ").concat(self.sentVault.getType().identifier)
+    }
+
     execute {
         if self.requiresOnboarding {
             // Onboard the Vault to the bridge


### PR DESCRIPTION
Related:
- https://github.com/onflow/flow-nft/issues/222
- https://github.com/onflow/flow-ft/issues/162

## Description

Including these assertions for more robust transaction guarantees and consistency with standard best practices.

[Related discord thread](https://discord.com/channels/613813861610684416/1260256184041209866)

______

For contributor use:

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 