### PR TITLE
Improve conversion of EVM addresses

### DIFF
--- a/cadence/scripts/evm/call.cdc
+++ b/cadence/scripts/evm/call.cdc
@@ -20,15 +20,12 @@ access(all) fun main(
     typeIdentifiers: [String]
 ): [AnyStruct] {
 
-    let evmAddressBytes: [UInt8] = evmContractAddressHex.decodeHex()
     let evmAddress = EVM.EVMAddress(
-            bytes: [
-                evmAddressBytes[0], evmAddressBytes[1], evmAddressBytes[2], evmAddressBytes[3], evmAddressBytes[4],
-                evmAddressBytes[5], evmAddressBytes[6], evmAddressBytes[7], evmAddressBytes[8], evmAddressBytes[9],
-                evmAddressBytes[10], evmAddressBytes[11], evmAddressBytes[12], evmAddressBytes[13], evmAddressBytes[14],
-                evmAddressBytes[15], evmAddressBytes[16], evmAddressBytes[17], evmAddressBytes[18], evmAddressBytes[19]
-            ]
-        )
+        bytes: evmContractAddressHex
+            .decodeHex()
+            .toConstantSized<[UInt8; 20]>()
+            ?? panic("Invalid EVM address")
+    )
 
     let data: [UInt8] = calldata.decodeHex()
 

--- a/cadence/scripts/evm/call.cdc
+++ b/cadence/scripts/evm/call.cdc
@@ -20,14 +20,9 @@ access(all) fun main(
     typeIdentifiers: [String]
 ): [AnyStruct] {
 
-    let evmAddress = EVM.EVMAddress(
-        bytes: evmContractAddressHex
-            .decodeHex()
-            .toConstantSized<[UInt8; 20]>()
-            ?? panic("Invalid EVM address")
-    )
+    let evmAddress = EVM.addressFromString(evmContractAddressHex)
 
-    let data: [UInt8] = calldata.decodeHex()
+    let data = calldata.decodeHex()
 
     let gatewayCOA = getAuthAccount<auth(BorrowValue) &Account>(gatewayAddress)
         .storage.borrow<auth(EVM.Call) &EVM.CadenceOwnedAccount>(

--- a/cadence/scripts/evm/get_balance.cdc
+++ b/cadence/scripts/evm/get_balance.cdc
@@ -3,7 +3,7 @@ import "EVM"
 /// Returns the Flow balance of of a given EVM address in FlowEVM
 ///
 access(all) fun main(address: String): UFix64 {
-    let bytes = address
+    let addressBytes = address
         .decodeHex()
         .toConstantSized<[UInt8; 20]>()
         ?? panic("Invalid EVM address")

--- a/cadence/scripts/evm/get_balance.cdc
+++ b/cadence/scripts/evm/get_balance.cdc
@@ -3,9 +3,5 @@ import "EVM"
 /// Returns the Flow balance of of a given EVM address in FlowEVM
 ///
 access(all) fun main(address: String): UFix64 {
-    let addressBytes = address
-        .decodeHex()
-        .toConstantSized<[UInt8; 20]>()
-        ?? panic("Invalid EVM address")
-    return EVM.EVMAddress(bytes: addressBytes).balance().inFLOW()
+    return EVM.addressFromString(address).balance().inFLOW()
 }

--- a/cadence/scripts/evm/get_balance.cdc
+++ b/cadence/scripts/evm/get_balance.cdc
@@ -3,12 +3,9 @@ import "EVM"
 /// Returns the Flow balance of of a given EVM address in FlowEVM
 ///
 access(all) fun main(address: String): UFix64 {
-    let bytes = address.decodeHex()
-    let addressBytes: [UInt8; 20] = [
-        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4],
-        bytes[5], bytes[6], bytes[7], bytes[8], bytes[9],
-        bytes[10], bytes[11], bytes[12], bytes[13], bytes[14],
-        bytes[15], bytes[16], bytes[17], bytes[18], bytes[19]
-    ]
+    let bytes = address
+        .decodeHex()
+        .toConstantSized<[UInt8; 20]>()
+        ?? panic("Invalid EVM address")
     return EVM.EVMAddress(bytes: addressBytes).balance().inFLOW()
 }

--- a/cadence/transactions/evm/call.cdc
+++ b/cadence/transactions/evm/call.cdc
@@ -8,16 +8,13 @@ transaction(evmContractAddressHex: String, calldata: String, gasLimit: UInt64, v
     let coa: auth(EVM.Call) &EVM.CadenceOwnedAccount
 
     prepare(signer: auth(BorrowValue) &Account) {
-        let evmAddressBytes: [UInt8] = evmContractAddressHex.toLower().decodeHex()
         self.evmAddress = EVM.EVMAddress(
-                bytes: [
-                    evmAddressBytes[0], evmAddressBytes[1], evmAddressBytes[2], evmAddressBytes[3], evmAddressBytes[4],
-                    evmAddressBytes[5], evmAddressBytes[6], evmAddressBytes[7], evmAddressBytes[8], evmAddressBytes[9],
-                    evmAddressBytes[10], evmAddressBytes[11], evmAddressBytes[12], evmAddressBytes[13], evmAddressBytes[14],
-                    evmAddressBytes[15], evmAddressBytes[16], evmAddressBytes[17], evmAddressBytes[18], evmAddressBytes[19]
-                ]
-            )
-        
+            bytes: evmContractAddressHex
+                .decodeHex()
+                .toConstantSized<[UInt8; 20]>()
+                ?? panic("Invalid EVM address")
+        )
+
         self.coa = signer.storage.borrow<auth(EVM.Call) &EVM.CadenceOwnedAccount>(from: /storage/evm)
             ?? panic("Could not borrow COA from provided gateway address")
     }

--- a/cadence/transactions/evm/call.cdc
+++ b/cadence/transactions/evm/call.cdc
@@ -8,12 +8,7 @@ transaction(evmContractAddressHex: String, calldata: String, gasLimit: UInt64, v
     let coa: auth(EVM.Call) &EVM.CadenceOwnedAccount
 
     prepare(signer: auth(BorrowValue) &Account) {
-        self.evmAddress = EVM.EVMAddress(
-            bytes: evmContractAddressHex
-                .decodeHex()
-                .toConstantSized<[UInt8; 20]>()
-                ?? panic("Invalid EVM address")
-        )
+        self.evmAddress = EVM.addressFromString(evmContractAddressHex)
 
         self.coa = signer.storage.borrow<auth(EVM.Call) &EVM.CadenceOwnedAccount>(from: /storage/evm)
             ?? panic("Could not borrow COA from provided gateway address")


### PR DESCRIPTION

## Description

Use `toConstantSized` function to convert `[UInt8]` to `[UInt8;20]` needed for `EVM.EVMAddress`

______

For contributor use:

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 