### PR TITLE
Add metadata discovery & resolution paths to escrow contracts

### DIFF
--- a/cadence/contracts/bridge/FlowEVMBridgeNFTEscrow.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeNFTEscrow.cdc
@@ -77,23 +77,6 @@ access(all) contract FlowEVMBridgeNFTEscrow {
         return nil
     }
 
-    /// Resolves the requested view type for the given NFT type if it is locked and supports the requested view type
-    ///
-    /// @param nftType: Type of the locked NFT
-    /// @param viewType: Type of the view to resolve
-    /// @param id: ID of the locked NFT
-    ///
-    /// @returns The resolved view as AnyStruct if the NFT is locked and the view is supported, otherwise returns nil
-    ///
-    access(all) fun resolveLockedNFTView(nftType: Type, id: UInt256, viewType: Type): AnyStruct? {
-        if let locker = self.borrowLocker(forType: nftType) {
-            if let cadenceID = locker.getCadenceID(from: id) {
-                return locker.borrowViewResolver(id: cadenceID)?.resolveView(viewType) ?? nil
-            }
-        }
-        return nil
-    }
-
     /**********************
         Bridge Methods
     ***********************/

--- a/cadence/contracts/bridge/FlowEVMBridgeTokenEscrow.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeTokenEscrow.cdc
@@ -51,18 +51,6 @@ access(all) contract FlowEVMBridgeTokenEscrow {
         return self.borrowLocker(forType: tokenType)?.getViews() ?? []
     }
 
-    /// Resolves the requested view type for the given FT type if it is locked and supports the requested view type
-    ///
-    /// @param tokenType: Type of the locked fungible tokens
-    /// @param viewType: Type of the view to resolve
-    ///
-    /// @returns The resolved view as AnyStruct if the vault is locked and the view is supported, otherwise returns nil
-    ///
-    access(all) fun resolveLockedTokenView(tokenType: Type, viewType: Type): AnyStruct? {
-        // The Locker implements Resolver, which has basic resolveView functionality
-        return self.borrowLocker(forType: tokenType)?.resolveView(viewType) ?? nil
-    }
-
     /**********************
         Bridge Methods
     ***********************/

--- a/cadence/scripts/escrow/get_locked_token_balance.cdc
+++ b/cadence/scripts/escrow/get_locked_token_balance.cdc
@@ -1,0 +1,11 @@
+import "FlowEVMBridgeTokenEscrow"
+
+/// Returns the balance of a given FungibleToken Vault type locked in escrow or nil if a vault of the given type is not
+/// locked in escrow
+///
+/// @param vaultTypeIdentifier: The type identifier of the FungibleToken Vault
+///
+access(all) fun main(vaultTypeIdentifier: String): UFix64? {
+    let tokenType = CompositeType(vaultTypeIdentifier) ?? panic("Malformed Vault type identifier=".concat(vaultTypeIdentifier))
+    return FlowEVMBridgeTokenEscrow.getLockedTokenBalance(tokenType: tokenType)
+}

--- a/cadence/scripts/escrow/get_nft_views.cdc
+++ b/cadence/scripts/escrow/get_nft_views.cdc
@@ -1,0 +1,16 @@
+import "NonFungibleToken"
+
+import "FlowEVMBridgeNFTEscrow"
+import "FlowEVMBridge"
+
+/// Returns the views supported by an escrowed NFT or nil if the NFT is not locked in escrow
+///
+/// @param nftTypeIdentifier: The type identifier of the NFT
+/// @param id: The ID of the NFT
+///
+/// @return The metadata view types supported by the escrowed NFT or nil if the NFT is not locked in escrow
+///
+access(all) fun main(nftTypeIdentifier: String, id: UInt64): [Type]? {
+    let type = CompositeType(nftTypeIdentifier) ?? panic("Malformed NFT type identifier=".concat(nftTypeIdentifier))
+    return FlowEVMBridgeNFTEscrow.getViews(nftType: type, id: id)
+}

--- a/cadence/scripts/escrow/get_vault_views.cdc
+++ b/cadence/scripts/escrow/get_vault_views.cdc
@@ -1,0 +1,16 @@
+import "NonFungibleToken"
+
+import "FlowEVMBridgeTokenEscrow"
+import "FlowEVMBridge"
+
+/// Returns the views supported by an escrowed FungibleToken Vault or nil if there is no Vault of the given type locked
+/// in escrow
+///
+/// @param vaultTypeIdentifier: The type identifier of the NFT
+///
+/// @return The metadata view types supported by the escrowed FT Vault or nil if there is not Vault locked in escrow
+///
+access(all) fun main(vaultTypeIdentifier: String, id: UInt64): [Type]? {
+    let type = CompositeType(vaultTypeIdentifier) ?? panic("Malformed Vault type identifier=".concat(vaultTypeIdentifier))
+    return FlowEVMBridgeTokenEscrow.getViews(tokenType: type)
+}

--- a/cadence/scripts/escrow/is_nft_locked.cdc
+++ b/cadence/scripts/escrow/is_nft_locked.cdc
@@ -11,6 +11,6 @@ import "FlowEVMBridge"
 /// @return true if the NFT is locked in escrow and false otherwise
 ///
 access(all) fun main(nftTypeIdentifier: String, id: UInt64): Bool {
-    let type = CompositeType(nftTypeIdentifier) ?? panic("Malformed type identifier")
+    let type = CompositeType(nftTypeIdentifier) ?? panic("Malformed NFT type identifier=".concat(nftTypeIdentifier))
     return FlowEVMBridgeNFTEscrow.isLocked(type: type, id: id)
 }

--- a/cadence/scripts/escrow/resolve_locked_nft_metadata.cdc
+++ b/cadence/scripts/escrow/resolve_locked_nft_metadata.cdc
@@ -13,8 +13,8 @@ import "FlowEVMBridge"
 /// @return The resolved view if the NFT is escrowed & the view is resolved by it or nil if the NFT is not locked
 ///
 access(all) fun main(nftTypeIdentifier: String, id: UInt256, viewIdentifier: String): AnyStruct? {
-    let nftType: Type = CompositeType(nftTypeIdentifier) ?? panic("Malformed nft type identifier")
-    let view: Type = CompositeType(viewIdentifier) ?? panic("Malformed view type identifier")
+    let nftType: Type = CompositeType(nftTypeIdentifier) ?? panic("Malformed NFT type identifier=".concat(nftTypeIdentifier))
+    let view: Type = CompositeType(viewIdentifier) ?? panic("Malformed view type identifier=".concat(viewIdentifier))
 
     return FlowEVMBridgeNFTEscrow.resolveLockedNFTView(nftType: nftType, id: id, viewType: view)
 }

--- a/cadence/scripts/escrow/resolve_locked_nft_metadata.cdc
+++ b/cadence/scripts/escrow/resolve_locked_nft_metadata.cdc
@@ -6,7 +6,7 @@ import "FlowEVMBridgeUtils"
 
 /// Resolves the view for the requested locked NFT or nil if the NFT is not locked
 /// NOTE: This functionality is not available via the escrow contract as `resolveView` is not a `view` method, but the
-///     escrow contract
+///     escrow contract does provide the necessary functionality to resolve the view from the context of a script
 ///
 /// @param bridgeAddress: The address of the bridge contract (included as the VM bridge address varies across networks)
 /// @param nftTypeIdentifier: The identifier of the NFT type

--- a/cadence/scripts/escrow/resolve_locked_nft_metadata.cdc
+++ b/cadence/scripts/escrow/resolve_locked_nft_metadata.cdc
@@ -2,19 +2,40 @@ import "NonFungibleToken"
 import "MetadataViews"
 
 import "FlowEVMBridgeNFTEscrow"
-import "FlowEVMBridge"
+import "FlowEVMBridgeUtils"
 
 /// Resolves the view for the requested locked NFT or nil if the NFT is not locked
+/// NOTE: This functionality is not available via the escrow contract as `resolveView` is not a `view` method, but the
+///     escrow contract
 ///
+/// @param bridgeAddress: The address of the bridge contract
 /// @param nftTypeIdentifier: The identifier of the NFT type
 /// @param id: The ERC721 id of the escrowed NFT
 /// @param viewIdentifier: The identifier of the view to resolve
 ///
 /// @return The resolved view if the NFT is escrowed & the view is resolved by it or nil if the NFT is not locked
 ///
-access(all) fun main(nftTypeIdentifier: String, id: UInt256, viewIdentifier: String): AnyStruct? {
+access(all) fun main(bridgeAddress: Address, nftTypeIdentifier: String, id: UInt256, viewIdentifier: String): AnyStruct? {
+    // Construct runtime types from provided identifiers
     let nftType: Type = CompositeType(nftTypeIdentifier) ?? panic("Malformed NFT type identifier=".concat(nftTypeIdentifier))
     let view: Type = CompositeType(viewIdentifier) ?? panic("Malformed view type identifier=".concat(viewIdentifier))
 
-    return FlowEVMBridgeNFTEscrow.resolveLockedNFTView(nftType: nftType, id: id, viewType: view)
+    // Derive the Locker path for the given NFT type
+    let lockerPath = FlowEVMBridgeUtils.deriveEscrowStoragePath(fromType: nftType)
+        ?? panic("Problem deriving Locker path for NFT type identifier=".concat(nftTypeIdentifier))
+
+    // Borrow the locker from the bridge account's storage
+    if let locker = getAuthAccount<auth(BorrowValue) &Account>(bridgeAddress).storage.borrow<&FlowEVMBridgeNFTEscrow.Locker>(
+        from: lockerPath
+    ) {
+        // Retrieve the NFT type's cadence ID from the locker
+        if let cadenceID = locker.getCadenceID(from: id) {
+            // Resolve the requested view for the given NFT type, returning nil if the view is not supported or the NFT
+            // is not locked in escrow
+            return locker.borrowViewResolver(id: cadenceID)?.resolveView(view)
+        }
+    }
+
+    // Return nil if no locker was found for the given NFT type
+    return nil
 }

--- a/cadence/scripts/escrow/resolve_locked_nft_metadata.cdc
+++ b/cadence/scripts/escrow/resolve_locked_nft_metadata.cdc
@@ -8,7 +8,7 @@ import "FlowEVMBridgeUtils"
 /// NOTE: This functionality is not available via the escrow contract as `resolveView` is not a `view` method, but the
 ///     escrow contract
 ///
-/// @param bridgeAddress: The address of the bridge contract
+/// @param bridgeAddress: The address of the bridge contract (included as the VM bridge address varies across networks)
 /// @param nftTypeIdentifier: The identifier of the NFT type
 /// @param id: The ERC721 id of the escrowed NFT
 /// @param viewIdentifier: The identifier of the view to resolve

--- a/cadence/scripts/escrow/resolve_locked_vault_metadata.cdc
+++ b/cadence/scripts/escrow/resolve_locked_vault_metadata.cdc
@@ -1,0 +1,19 @@
+import "NonFungibleToken"
+import "MetadataViews"
+
+import "FlowEVMBridgeTokenEscrow"
+import "FlowEVMBridge"
+
+/// Resolves the view for the requested locked Vault or nil if the Vault is not locked in escrow
+///
+/// @param vaultTypeIdentifier: The identifier of the Vault type
+/// @param viewIdentifier: The identifier of the view to resolve
+///
+/// @return The resolved view if the Vault is escrowed & the view is resolved by it or nil if the Vault is not locked
+///
+access(all) fun main(vaultTypeIdentifier: String, viewIdentifier: String): AnyStruct? {
+    let vaultType: Type = CompositeType(vaultTypeIdentifier) ?? panic("Malformed vault type identifier=".concat(vaultTypeIdentifier))
+    let view: Type = CompositeType(viewIdentifier) ?? panic("Malformed view type identifier=".concat(viewIdentifier))
+
+    return FlowEVMBridgeTokenEscrow.resolveLockedTokenView(tokenType: vaultType, viewType: view)
+}

--- a/cadence/scripts/escrow/resolve_locked_vault_metadata.cdc
+++ b/cadence/scripts/escrow/resolve_locked_vault_metadata.cdc
@@ -2,18 +2,31 @@ import "NonFungibleToken"
 import "MetadataViews"
 
 import "FlowEVMBridgeTokenEscrow"
-import "FlowEVMBridge"
+import "FlowEVMBridgeUtils"
 
 /// Resolves the view for the requested locked Vault or nil if the Vault is not locked in escrow
 ///
+/// @param bridgeAddress: The address of the bridge contract (included as the VM bridge address varies across networks)
 /// @param vaultTypeIdentifier: The identifier of the Vault type
 /// @param viewIdentifier: The identifier of the view to resolve
 ///
 /// @return The resolved view if the Vault is escrowed & the view is resolved by it or nil if the Vault is not locked
 ///
-access(all) fun main(vaultTypeIdentifier: String, viewIdentifier: String): AnyStruct? {
+access(all) fun main(bridgeAddress: Address, vaultTypeIdentifier: String, viewIdentifier: String): AnyStruct? {
+    // Construct runtime types from provided identifiers
     let vaultType: Type = CompositeType(vaultTypeIdentifier) ?? panic("Malformed vault type identifier=".concat(vaultTypeIdentifier))
     let view: Type = CompositeType(viewIdentifier) ?? panic("Malformed view type identifier=".concat(viewIdentifier))
 
-    return FlowEVMBridgeTokenEscrow.resolveLockedTokenView(tokenType: vaultType, viewType: view)
+    // Derive the Locker path for the given Vault type
+    let lockerPath = FlowEVMBridgeUtils.deriveEscrowStoragePath(fromType: vaultType)
+        ?? panic("Problem deriving Locker path for NFT type identifier=".concat(vaultTypeIdentifier))
+
+    // Borrow the locker from the bridge account's storage & return the requested view if the locker exists
+    if let locker = getAuthAccount<auth(BorrowValue) &Account>(bridgeAddress).storage.borrow<&FlowEVMBridgeTokenEscrow.Locker>(
+        from: lockerPath
+    ) {
+        return locker.resolveView(view)
+    }
+
+    return nil
 }

--- a/cadence/scripts/escrow/resolve_locked_vault_metadata.cdc
+++ b/cadence/scripts/escrow/resolve_locked_vault_metadata.cdc
@@ -5,6 +5,8 @@ import "FlowEVMBridgeTokenEscrow"
 import "FlowEVMBridgeUtils"
 
 /// Resolves the view for the requested locked Vault or nil if the Vault is not locked in escrow
+/// NOTE: This functionality is not available via the escrow contract as `resolveView` is not a `view` method, but the
+///     escrow contract does provide the necessary functionality to resolve the view from the context of a script
 ///
 /// @param bridgeAddress: The address of the bridge contract (included as the VM bridge address varies across networks)
 /// @param vaultTypeIdentifier: The identifier of the Vault type

--- a/cadence/tests/flow_evm_bridge_tests.cdc
+++ b/cadence/tests/flow_evm_bridge_tests.cdc
@@ -4,6 +4,7 @@ import BlockchainHelpers
 import "FungibleToken"
 import "NonFungibleToken"
 import "MetadataViews"
+import "FungibleTokenMetadataViews"
 import "ExampleNFT"
 import "ExampleToken"
 import "FlowStorageFees"
@@ -1058,8 +1059,8 @@ fun testBridgeCadenceNativeNFTToEVMSucceeds() {
     let isNFTLocked = isNFTLocked(nftTypeIdentifier: exampleNFTIdentifier, id: mintedNFTID)
     Test.assertEqual(true, isNFTLocked)
 
-    let metadata = resolveLockedNFTMetadata(bridgeAddress: bridgeAccount.address, nftTypeIdentifier: exampleNFTIdentifier, id: UInt256(mintedNFTID), viewIdentifier: Type<MetadataViews.Display>().identifier)
-    Test.assert(metadata != nil, message: "Expected metadata to be resolved")
+    let metadata = resolveLockedNFTView(bridgeAddress: bridgeAccount.address, nftTypeIdentifier: exampleNFTIdentifier, id: UInt256(mintedNFTID), viewIdentifier: Type<MetadataViews.Display>().identifier)
+    Test.assert(metadata != nil, message: "Expected NFT metadata to be resolved from escrow but none was returned")
 }
 
 access(all)
@@ -1274,6 +1275,9 @@ fun testBridgeCadenceNativeTokenToEVMSucceeds() {
     // Confirm the token is locked
     let lockedBalance = getLockedTokenBalance(vaultTypeIdentifier: exampleTokenIdentifier) ?? panic("Problem getting locked balance")
     Test.assertEqual(exampleTokenMintAmount, lockedBalance)
+
+    let metadata = resolveLockedTokenView(bridgeAddress: bridgeAccount.address, vaultTypeIdentifier: exampleTokenIdentifier, viewIdentifier: Type<FungibleTokenMetadataViews.FTDisplay>().identifier)
+    Test.assert(metadata != nil, message: "Expected Vault metadata to be resolved from escrow but none was returned")
 }
 
 access(all)

--- a/cadence/tests/flow_evm_bridge_tests.cdc
+++ b/cadence/tests/flow_evm_bridge_tests.cdc
@@ -1053,6 +1053,9 @@ fun testBridgeCadenceNativeNFTToEVMSucceeds() {
     )
     Test.expect(isOwnerResult, Test.beSucceeded())
     Test.assertEqual(true, isOwnerResult.returnValue as! Bool? ?? panic("Problem getting owner status"))
+
+    let isNFTLocked = isNFTLocked(nftTypeIdentifier: exampleNFTIdentifier, id: mintedNFTID)
+    Test.assertEqual(true, isNFTLocked)
 }
 
 access(all)
@@ -1091,6 +1094,9 @@ fun testCrossVMTransferCadenceNativeNFTFromEVMSucceeds() {
     let bobOwnedIDs = getIDs(ownerAddr: bob.address, storagePathIdentifier: "cadenceExampleNFTCollection")
     Test.assertEqual(1, bobOwnedIDs.length)
     Test.assertEqual(mintedNFTID, bobOwnedIDs[0])
+
+    let isNFTLocked = isNFTLocked(nftTypeIdentifier: exampleNFTIdentifier, id: mintedNFTID)
+    Test.assertEqual(false, isNFTLocked)
 }
 
 access(all)
@@ -1260,6 +1266,10 @@ fun testBridgeCadenceNativeTokenToEVMSucceeds() {
     let expectedEVMBalance = ufix64ToUInt256(exampleTokenMintAmount, decimals: decimals)
     let evmBalance = balanceOf(evmAddressHex: aliceCOAAddressHex, erc20AddressHex: associatedEVMAddressHex)
     Test.assertEqual(expectedEVMBalance, evmBalance)
+
+    // Confirm the token is locked
+    let lockedBalance = getLockedTokenBalance(vaultTypeIdentifier: exampleTokenIdentifier) ?? panic("Problem getting locked balance")
+    Test.assertEqual(exampleTokenMintAmount, lockedBalance)
 }
 
 access(all)

--- a/cadence/tests/flow_evm_bridge_tests.cdc
+++ b/cadence/tests/flow_evm_bridge_tests.cdc
@@ -3,6 +3,7 @@ import BlockchainHelpers
 
 import "FungibleToken"
 import "NonFungibleToken"
+import "MetadataViews"
 import "ExampleNFT"
 import "ExampleToken"
 import "FlowStorageFees"
@@ -1056,6 +1057,9 @@ fun testBridgeCadenceNativeNFTToEVMSucceeds() {
 
     let isNFTLocked = isNFTLocked(nftTypeIdentifier: exampleNFTIdentifier, id: mintedNFTID)
     Test.assertEqual(true, isNFTLocked)
+
+    let metadata = resolveLockedNFTMetadata(bridgeAddress: bridgeAccount.address, nftTypeIdentifier: exampleNFTIdentifier, id: UInt256(mintedNFTID), viewIdentifier: Type<MetadataViews.Display>().identifier)
+    Test.assert(metadata != nil, message: "Expected metadata to be resolved")
 }
 
 access(all)

--- a/cadence/tests/test_helpers.cdc
+++ b/cadence/tests/test_helpers.cdc
@@ -371,6 +371,16 @@ fun getLockedTokenBalance(vaultTypeIdentifier: String): UFix64? {
     return balanceResult.returnValue as! UFix64?
 }
 
+access(all)
+fun resolveLockedNFTMetadata(bridgeAddress: Address, nftTypeIdentifier: String, id: UInt256, viewIdentifier: String): AnyStruct? {
+    let resolvedViewResult = _executeScript(
+        "../scripts/escrow/resolve_locked_nft_metadata.cdc",
+        [bridgeAddress, nftTypeIdentifier, id, viewIdentifier]
+    )
+    Test.expect(resolvedViewResult, Test.beSucceeded())
+    return resolvedViewResult.returnValue as! AnyStruct?
+}
+
 /* --- Transaction Helpers --- */
 
 access(all)

--- a/cadence/tests/test_helpers.cdc
+++ b/cadence/tests/test_helpers.cdc
@@ -351,6 +351,26 @@ fun evmAddressRequiresOnboarding(_ addressHex: String): Bool? {
     return onboardingRequiredResult.returnValue as! Bool? ?? panic("Problem getting onboarding requirement")
 }
 
+access(all)
+fun isNFTLocked(nftTypeIdentifier: String, id: UInt64): Bool {
+    let isLockedResult = _executeScript(
+        "../scripts/escrow/is_nft_locked.cdc",
+        [nftTypeIdentifier, id]
+    )
+    Test.expect(isLockedResult, Test.beSucceeded())
+    return isLockedResult.returnValue as! Bool? ?? panic("Problem getting locked status")
+}
+
+access(all)
+fun getLockedTokenBalance(vaultTypeIdentifier: String): UFix64? {
+    let balanceResult = _executeScript(
+        "../scripts/escrow/get_locked_token_balance.cdc",
+        [vaultTypeIdentifier]
+    )
+    Test.expect(balanceResult, Test.beSucceeded())
+    return balanceResult.returnValue as! UFix64?
+}
+
 /* --- Transaction Helpers --- */
 
 access(all)

--- a/cadence/tests/test_helpers.cdc
+++ b/cadence/tests/test_helpers.cdc
@@ -372,10 +372,20 @@ fun getLockedTokenBalance(vaultTypeIdentifier: String): UFix64? {
 }
 
 access(all)
-fun resolveLockedNFTMetadata(bridgeAddress: Address, nftTypeIdentifier: String, id: UInt256, viewIdentifier: String): AnyStruct? {
+fun resolveLockedNFTView(bridgeAddress: Address, nftTypeIdentifier: String, id: UInt256, viewIdentifier: String): AnyStruct? {
     let resolvedViewResult = _executeScript(
         "../scripts/escrow/resolve_locked_nft_metadata.cdc",
         [bridgeAddress, nftTypeIdentifier, id, viewIdentifier]
+    )
+    Test.expect(resolvedViewResult, Test.beSucceeded())
+    return resolvedViewResult.returnValue as! AnyStruct?
+}
+
+access(all)
+fun resolveLockedTokenView(bridgeAddress: Address, vaultTypeIdentifier: String, viewIdentifier: String): AnyStruct? {
+    let resolvedViewResult = _executeScript(
+        "../scripts/escrow/resolve_locked_vault_metadata.cdc",
+        [bridgeAddress, vaultTypeIdentifier, viewIdentifier]
     )
     Test.expect(resolvedViewResult, Test.beSucceeded())
     return resolvedViewResult.returnValue as! AnyStruct?


### PR DESCRIPTION
Closes:  #112 cc: @bjartek
Related: #99 

> ℹ️ Cadence CI seems to be failing on CLI install because there was a [recent release](https://github.com/onflow/flow-cli/releases/tag/v1.21.0-cadence-v1.0.0-preview.38) of Flow CLI which isn't yet available. I'll run CI again after some time to confirm passing tests.

## Description

- Enhances error messages in escrow contracts & scripts
- Adds the ability to discover supported metadata views from NFTs in locked in escrow
- Adds supporting scripts for new and existing escrow functionality

______

For contributor use:

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 