### PR TITLE
Add type assertion to onboarding Vault

### DIFF
--- a/cadence/contracts/bridge/FlowEVMBridge.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridge.cdc
@@ -99,8 +99,13 @@ contract FlowEVMBridge : IFlowEVMNFTBridge, IFlowEVMTokenBridge {
         } else if type.isSubtype(of: Type<@{FungibleToken.Vault}>()) {
             let createVaultFunction = FlowEVMBridgeUtils.getCreateEmptyVaultFunction(forType: type)
                 ?? panic("Could not retrieve createEmptyVault function for the given type")
+            let vault <-createVaultFunction(type)
+            assert(
+                vault.getType() == type,
+                message: "Requested to onboard type=".concat(type.identifier).concat( "but contract returned type=").concat(vault.getType().identifier)
+            )
             FlowEVMBridgeTokenEscrow.initializeEscrow(
-                with: <-createVaultFunction(type),
+                with: <-vault,
                 name: onboardingValues.name,
                 symbol: onboardingValues.symbol,
                 decimals: onboardingValues.decimals!,


### PR DESCRIPTION
## Description

- Asserts that the actual onboarded vault is the type that is declared in the `onboardByType` function arg. This should be covered by the `FungibleToken.createEmptyVault` post condition ensuring that the result type is the same as the vault type requested. However adding this explicitly ensures that the condition is owned and not a condition enforced by a dependency.

______

For contributor use:

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 