### PR TITLE
Fix cases of underflow in event of storage decrease

### DIFF
--- a/cadence/contracts/bridge/FlowEVMBridgeNFTEscrow.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeNFTEscrow.cdc
@@ -104,7 +104,14 @@ access(all) contract FlowEVMBridgeNFTEscrow {
         locker.deposit(token: <-nft)
         let postStorageSnapshot = self.account.storage.used
 
-        return postStorageSnapshot - preStorageSnapshot
+        // Return the amount of storage used by the locker after storing the NFT
+        if postStorageSnapshot < preStorageSnapshot {
+            // Due to atree inlining, account storage usage may counterintuitively decrease at times - return 0
+            return 0
+        } else {
+            // Otherwise, return the storage usage delta
+            return postStorageSnapshot - preStorageSnapshot
+        }
     }
 
     /// Unlocks the NFT of the given type and ID, reverting if it isn't in escrow

--- a/cadence/contracts/bridge/FlowEVMBridgeTokenEscrow.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeTokenEscrow.cdc
@@ -97,7 +97,14 @@ access(all) contract FlowEVMBridgeTokenEscrow {
         locker.deposit(from: <-vault)
         let postStorageSnapshot = self.account.storage.used
 
-        return postStorageSnapshot - preStorageSnapshot
+        // Return the amount of storage used by the locker after storing the NFT
+        if postStorageSnapshot < preStorageSnapshot {
+            // Due to atree inlining, account storage usage may counterintuitively decrease at times - return 0
+            return 0
+        } else {
+            // Otherwise, return the storage usage delta
+            return postStorageSnapshot - preStorageSnapshot
+        }
     }
 
     /// Unlocks the tokens of the given type and amount, reverting if it isn't in escrow


### PR DESCRIPTION
Closes: #127

## Description

- Guards against instances where escrowing an asset actually decreases account storage usage due to underlying storage implementation. This may be an instance where storage blocks are reshuffled such that to total stored object is more compact and thus consumes less storage than the object preceding the newly stored asset.

______

For contributor use:

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 