### PR TITLE
feat: add a new transaction for creating new account with coa

### DIFF
--- a/cadence/transactions/evm/create_new_account_with_coa.cdc
+++ b/cadence/transactions/evm/create_new_account_with_coa.cdc
@@ -13,38 +13,38 @@ transaction(
     let auth: auth(Storage, Keys, Capabilities) &Account
 
     prepare(signer: auth(Storage, Keys, Capabilities) &Account) {
-		pre {
-			signatureAlgorithm >= 1 && signatureAlgorithm <= 3:
+        pre {
+            signatureAlgorithm >= 1 && signatureAlgorithm <= 3:
                 "Cannot add Key: Must provide a signature algorithm raw value that corresponds to "
                 .concat("one of the available signature algorithms for Flow keys.")
                 .concat("You provided ").concat(signatureAlgorithm.toString())
                 .concat(" but the options are either 1 (ECDSA_P256), 2 (ECDSA_secp256k1), or 3 (BLS_BLS12_381).")
-			hashAlgorithm >= 1 && hashAlgorithm <= 6:
+            hashAlgorithm >= 1 && hashAlgorithm <= 6:
                 "Cannot add Key: Must provide a hash algorithm raw value that corresponds to "
                 .concat("one of of the available hash algorithms for Flow keys.")
                 .concat("You provided ").concat(hashAlgorithm.toString())
                 .concat(" but the options are 1 (SHA2_256), 2 (SHA2_384), 3 (SHA3_256), ")
                 .concat("4 (SHA3_384), 5 (KMAC128_BLS_BLS12_381), or 6 (KECCAK_256).")
-			weight <= 1000.0:
+            weight <= 1000.0:
                 "Cannot add Key: The key weight must be between 0 and 1000."
                 .concat(" You provided ").concat(weight.toString()).concat(" which is invalid.")
-		}
+        }
 
         self.auth = signer
     }
 
     execute {
         // Create a new public key
-		let publicKey = PublicKey(
-			publicKey: key.decodeHex(),
-			signatureAlgorithm: SignatureAlgorithm(rawValue: signatureAlgorithm)!
-		)
+        let publicKey = PublicKey(
+            publicKey: key.decodeHex(),
+            signatureAlgorithm: SignatureAlgorithm(rawValue: signatureAlgorithm)!
+        )
 
         // Create a new account
-		let account = Account(payer: self.auth)
+        let account = Account(payer: self.auth)
 
         // Add the public key to the account
-		account.keys.add(
+        account.keys.add(
             publicKey: publicKey,
             hashAlgorithm: HashAlgorithm(rawValue: hashAlgorithm)!,
             weight: weight

--- a/cadence/transactions/evm/create_new_account_with_coa.cdc
+++ b/cadence/transactions/evm/create_new_account_with_coa.cdc
@@ -10,9 +10,9 @@ transaction(
     signatureAlgorithm: UInt8, // signature algorithm to be used for the account
     hashAlgorithm: UInt8, // hash algorithm to be used for the account
 ) {
-    let auth: auth(Storage, Keys, Capabilities) &Account
+    let auth: auth(BorrowValue) &Account
 
-    prepare(signer: auth(Storage, Keys, Capabilities) &Account) {
+    prepare(signer: auth(BorrowValue) &Account) {
         pre {
             signatureAlgorithm == 1 || signatureAlgorithm == 2:
                 "Cannot add Key: Must provide a signature algorithm raw value that corresponds to "

--- a/cadence/transactions/evm/create_new_account_with_coa.cdc
+++ b/cadence/transactions/evm/create_new_account_with_coa.cdc
@@ -2,32 +2,28 @@ import Crypto
 
 import "EVM"
 
-/// Creates a new Flow Address and EVM account with a Cadence Owned Account (COA) stored in the account's storage.
+/// Creates a new Flow Address with a single full-weight key and its EVM account, which is
+/// a Cadence Owned Account (COA) stored in the account's storage.
 ///
 transaction(
     key: String,  // key to be used for the account
     signatureAlgorithm: UInt8, // signature algorithm to be used for the account
     hashAlgorithm: UInt8, // hash algorithm to be used for the account
-    weight: UFix64, // weight to be used for the account
 ) {
     let auth: auth(Storage, Keys, Capabilities) &Account
 
     prepare(signer: auth(Storage, Keys, Capabilities) &Account) {
         pre {
-            signatureAlgorithm >= 1 && signatureAlgorithm <= 3:
+            signatureAlgorithm == 1 || signatureAlgorithm == 2:
                 "Cannot add Key: Must provide a signature algorithm raw value that corresponds to "
                 .concat("one of the available signature algorithms for Flow keys.")
                 .concat("You provided ").concat(signatureAlgorithm.toString())
-                .concat(" but the options are either 1 (ECDSA_P256), 2 (ECDSA_secp256k1), or 3 (BLS_BLS12_381).")
-            hashAlgorithm >= 1 && hashAlgorithm <= 6:
+                .concat(" but the options are either 1 (ECDSA_P256), 2 (ECDSA_secp256k1).")
+            hashAlgorithm == 1 || hashAlgorithm == 3:
                 "Cannot add Key: Must provide a hash algorithm raw value that corresponds to "
                 .concat("one of of the available hash algorithms for Flow keys.")
                 .concat("You provided ").concat(hashAlgorithm.toString())
-                .concat(" but the options are 1 (SHA2_256), 2 (SHA2_384), 3 (SHA3_256), ")
-                .concat("4 (SHA3_384), 5 (KMAC128_BLS_BLS12_381), or 6 (KECCAK_256).")
-            weight <= 1000.0:
-                "Cannot add Key: The key weight must be between 0 and 1000."
-                .concat(" You provided ").concat(weight.toString()).concat(" which is invalid.")
+                .concat(" but the options are 1 (SHA2_256), 3 (SHA3_256), ")
         }
 
         self.auth = signer
@@ -47,7 +43,7 @@ transaction(
         account.keys.add(
             publicKey: publicKey,
             hashAlgorithm: HashAlgorithm(rawValue: hashAlgorithm)!,
-            weight: weight
+            weight: 1000.0
         )
 
         // Create a new COA

--- a/cadence/transactions/evm/create_new_account_with_coa.cdc
+++ b/cadence/transactions/evm/create_new_account_with_coa.cdc
@@ -1,0 +1,64 @@
+import Crypto
+
+import "EVM"
+
+/// Creates a new Flow Address and EVM account with a Cadence Owned Account (COA) stored in the account's storage.
+///
+transaction(
+    key: String,  // key to be used for the account
+    signatureAlgorithm: UInt8, // signature algorithm to be used for the account
+    hashAlgorithm: UInt8, // hash algorithm to be used for the account
+    weight: UFix64, // weight to be used for the account
+) {
+    let auth: auth(Storage, Keys, Capabilities) &Account
+
+    prepare(signer: auth(Storage, Keys, Capabilities) &Account) {
+		pre {
+			signatureAlgorithm >= 1 && signatureAlgorithm <= 3:
+                "Cannot add Key: Must provide a signature algorithm raw value that corresponds to "
+                .concat("one of the available signature algorithms for Flow keys.")
+                .concat("You provided ").concat(signatureAlgorithm.toString())
+                .concat(" but the options are either 1 (ECDSA_P256), 2 (ECDSA_secp256k1), or 3 (BLS_BLS12_381).")
+			hashAlgorithm >= 1 && hashAlgorithm <= 6:
+                "Cannot add Key: Must provide a hash algorithm raw value that corresponds to "
+                .concat("one of of the available hash algorithms for Flow keys.")
+                .concat("You provided ").concat(hashAlgorithm.toString())
+                .concat(" but the options are 1 (SHA2_256), 2 (SHA2_384), 3 (SHA3_256), ")
+                .concat("4 (SHA3_384), 5 (KMAC128_BLS_BLS12_381), or 6 (KECCAK_256).")
+			weight <= 1000.0:
+                "Cannot add Key: The key weight must be between 0 and 1000."
+                .concat(" You provided ").concat(weight.toString()).concat(" which is invalid.")
+		}
+
+        self.auth = signer
+    }
+
+    execute {
+        // Create a new public key
+		let publicKey = PublicKey(
+			publicKey: key.decodeHex(),
+			signatureAlgorithm: SignatureAlgorithm(rawValue: signatureAlgorithm)!
+		)
+
+        // Create a new account
+		let account = Account(payer: self.auth)
+
+        // Add the public key to the account
+		account.keys.add(
+            publicKey: publicKey,
+            hashAlgorithm: HashAlgorithm(rawValue: hashAlgorithm)!,
+            weight: weight
+        )
+
+        // Create a new COA
+        let coa <- EVM.createCadenceOwnedAccount()
+
+        // Save the COA to the new account
+        let storagePath = StoragePath(identifier: "evm")!
+        let publicPath = PublicPath(identifier: "evm")!
+        account.storage.save<@EVM.CadenceOwnedAccount>(<-coa, to: storagePath)
+        let addressableCap = account.capabilities.storage.issue<&EVM.CadenceOwnedAccount>(storagePath)
+        account.capabilities.unpublish(publicPath)
+        account.capabilities.publish(addressableCap, at: publicPath)
+    }
+}

--- a/cadence/transactions/evm/create_new_account_with_coa.cdc
+++ b/cadence/transactions/evm/create_new_account_with_coa.cdc
@@ -23,7 +23,7 @@ transaction(
                 "Cannot add Key: Must provide a hash algorithm raw value that corresponds to "
                 .concat("one of of the available hash algorithms for Flow keys.")
                 .concat("You provided ").concat(hashAlgorithm.toString())
-                .concat(" but the options are 1 (SHA2_256), 3 (SHA3_256), ")
+                .concat(" but the options are 1 (SHA2_256), 3 (SHA3_256).")
         }
 
         self.auth = signer


### PR DESCRIPTION
## Description

This transaction is mainly used by CEXs.
It is a combined transaction for creating new accounts and creating COA resources.
Help CEX create COA addresses at the same time when creating user Flow deposit addresses.

______

For contributor use:

- [ ] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 