### PR TITLE
Optimize serialization

### DIFF
--- a/cadence/contracts/utils/Serialize.cdc
+++ b/cadence/contracts/utils/Serialize.cdc
@@ -90,7 +90,7 @@ contract Serialize {
     access(all)
     fun arrayToJSONString(_ arr: [AnyStruct]): String? {
         let parts: [String]= []
-        for i, element in arr {
+        for element in arr {
             let serializedElement = self.tryToJSONString(element)
             if serializedElement == nil {
                 continue
@@ -112,7 +112,7 @@ contract Serialize {
             }
         }
         let parts: [String] = []
-        for i, key in dict.keys {
+        for key in dict.keys {
             let serializedValue = self.tryToJSONString(dict[key]!)
             if serializedValue == nil {
                 continue

--- a/cadence/contracts/utils/Serialize.cdc
+++ b/cadence/contracts/utils/Serialize.cdc
@@ -5,7 +5,7 @@ import "NonFungibleToken"
 /// This contract is a utility for serializing primitive types, arrays, and common metadata mapping formats to JSON
 /// compatible strings. Also included are interfaces enabling custom serialization for structs and resources.
 ///
-/// Special thanks to @austinkline for the idea and initial implementation.
+/// Special thanks to @austinkline for the idea and initial implementation & @bjartek + @bluesign for optimizations.
 ///
 access(all)
 contract Serialize {

--- a/cadence/contracts/utils/Serialize.cdc
+++ b/cadence/contracts/utils/Serialize.cdc
@@ -27,59 +27,59 @@ contract Serialize {
             case Type<Never?>():
                 return "\"nil\""
             case Type<String>():
-                return "\"".concat(value as! String).concat("\"")
+                return String.join(["\"", value as! String, "\"" ], separator: "")
             case Type<String?>():
-                return "\"".concat(value as? String ?? "nil").concat("\"")
+                return String.join(["\"", value as? String ?? "nil", "\"" ], separator: "")
             case Type<Character>():
-                return "\"".concat((value as! Character).toString()).concat("\"")
+                return String.join(["\"", (value as! Character).toString(), "\"" ], separator: "")
             case Type<Bool>():
-                return "\"".concat(value as! Bool ? "true" : "false").concat("\"")
+                return String.join(["\"", value as! Bool ? "true" : "false", "\"" ], separator: "")
             case Type<Address>():
-                return "\"".concat((value as! Address).toString()).concat("\"")
+                return String.join(["\"", (value as! Address).toString(), "\"" ], separator: "")
             case Type<Address?>():
-                return "\"".concat((value as? Address)?.toString() ?? "nil").concat("\"")
+                return String.join(["\"", (value as? Address)?.toString() ?? "nil", "\"" ], separator: "")
             case Type<Int8>():
-                return "\"".concat((value as! Int8).toString()).concat("\"")
+                return String.join(["\"", (value as! Int8).toString(), "\"" ], separator: "")
             case Type<Int16>():
-                return "\"".concat((value as! Int16).toString()).concat("\"")
+                return String.join(["\"", (value as! Int16).toString(), "\"" ], separator: "")
             case Type<Int32>():
-                return "\"".concat((value as! Int32).toString()).concat("\"")
+                return String.join(["\"", (value as! Int32).toString(), "\"" ], separator: "")
             case Type<Int64>():
-                return "\"".concat((value as! Int64).toString()).concat("\"")
+                return String.join(["\"", (value as! Int64).toString(), "\"" ], separator: "")
             case Type<Int128>():
-                return "\"".concat((value as! Int128).toString()).concat("\"")
+                return String.join(["\"", (value as! Int128).toString(), "\"" ], separator: "")
             case Type<Int256>():
-                return "\"".concat((value as! Int256).toString()).concat("\"")
+                return String.join(["\"", (value as! Int256).toString(), "\"" ], separator: "")
             case Type<Int>():
-                return "\"".concat((value as! Int).toString()).concat("\"")
+                return String.join(["\"", (value as! Int).toString(), "\"" ], separator: "")
             case Type<UInt8>():
-                return "\"".concat((value as! UInt8).toString()).concat("\"")
+                return String.join(["\"", (value as! UInt8).toString(), "\"" ], separator: "")
             case Type<UInt16>():
-                return "\"".concat((value as! UInt16).toString()).concat("\"")
+                return String.join(["\"", (value as! UInt16).toString(), "\"" ], separator: "")
             case Type<UInt32>():
-                return "\"".concat((value as! UInt32).toString()).concat("\"")
+                return String.join(["\"", (value as! UInt32).toString(), "\"" ], separator: "")
             case Type<UInt64>():
-                return "\"".concat((value as! UInt64).toString()).concat("\"")
+                return String.join(["\"", (value as! UInt64).toString(), "\"" ], separator: "")
             case Type<UInt128>():
-                return "\"".concat((value as! UInt128).toString()).concat("\"")
+                return String.join(["\"", (value as! UInt128).toString(), "\"" ], separator: "")
             case Type<UInt256>():
-                return "\"".concat((value as! UInt256).toString()).concat("\"")
+                return String.join(["\"", (value as! UInt256).toString(), "\"" ], separator: "")
             case Type<UInt>():
-                return "\"".concat((value as! UInt).toString()).concat("\"")
+                return String.join(["\"", (value as! UInt).toString(), "\"" ], separator: "")
             case Type<Word8>():
-                return "\"".concat((value as! Word8).toString()).concat("\"")
+                return String.join(["\"", (value as! Word8).toString(), "\"" ], separator: "")
             case Type<Word16>():
-                return "\"".concat((value as! Word16).toString()).concat("\"")
+                return String.join(["\"", (value as! Word16).toString(), "\"" ], separator: "")
             case Type<Word32>():
-                return "\"".concat((value as! Word32).toString()).concat("\"")
+                return String.join(["\"", (value as! Word32).toString(), "\"" ], separator: "")
             case Type<Word64>():
-                return "\"".concat((value as! Word64).toString()).concat("\"")
+                return String.join(["\"", (value as! Word64).toString(), "\"" ], separator: "")
             case Type<Word128>():
-                return "\"".concat((value as! Word128).toString()).concat("\"")
+                return String.join(["\"", (value as! Word128).toString(), "\"" ], separator: "")
             case Type<Word256>():
-                return "\"".concat((value as! Word256).toString()).concat("\"")
+                return String.join(["\"", (value as! Word256).toString(), "\"" ], separator: "")
             case Type<UFix64>():
-                return "\"".concat((value as! UFix64).toString()).concat("\"")
+                return String.join(["\"", (value as! UFix64).toString(), "\"" ], separator: "")
             default:
                 return nil
         }
@@ -89,24 +89,15 @@ contract Serialize {
     ///
     access(all)
     fun arrayToJSONString(_ arr: [AnyStruct]): String? {
-        var serializedArr = "["
-        let arrLength = arr.length
+        let parts: [String]= []
         for i, element in arr {
             let serializedElement = self.tryToJSONString(element)
             if serializedElement == nil {
-                if i == arrLength - 1 && serializedArr.length > 1 && serializedArr[serializedArr.length - 2] == "," {
-                    // Remove trailing comma as this element could not be serialized
-                    serializedArr = serializedArr.slice(from: 0, upTo: serializedArr.length - 2)
-                }
                 continue
             }
-            serializedArr = serializedArr.concat(serializedElement!)
-            // Add a comma if there are more elements to serialize
-            if i < arr.length - 1 {
-                serializedArr = serializedArr.concat(", ")
-            }
+            parts.append(serializedElement!)
         }
-        return serializedArr.concat("]")
+        return "[".concat(String.join(parts, separator: ", ")).concat("]")
     }
 
     /// Returns a serialized representation of the given String-indexed mapping or nil if the value is not serializable.
@@ -120,22 +111,15 @@ contract Serialize {
                 dict.remove(key: k)
             }
         }
-        var serializedDict = "{"
-        let dictLength = dict.length
+        let parts: [String] = []
         for i, key in dict.keys {
             let serializedValue = self.tryToJSONString(dict[key]!)
             if serializedValue == nil {
-                if i == dictLength - 1  && serializedDict.length > 1 && serializedDict[serializedDict.length - 2] == "," {
-                    // Remove trailing comma as this element could not be serialized
-                    serializedDict = serializedDict.slice(from: 0, upTo: serializedDict.length - 2)
-                }
                 continue
             }
-            serializedDict = serializedDict.concat(self.tryToJSONString(key)!).concat(": ").concat(serializedValue!)
-            if i < dict.length - 1 {
-                serializedDict = serializedDict.concat(", ")
-            }
+            let serialializedKeyValue = String.join([self.tryToJSONString(key)!, serializedValue!], separator: ": ")
+            parts.append(serialializedKeyValue)
         }
-        return serializedDict.concat("}")
+        return "{".concat(String.join(parts, separator: ", ")).concat("}")
     }
 }

--- a/cadence/contracts/utils/SerializeMetadata.cdc
+++ b/cadence/contracts/utils/SerializeMetadata.cdc
@@ -8,6 +8,8 @@ import "Serialize"
 /// This contract defines methods for serializing NFT metadata as a JSON compatible string, according to the common
 /// OpenSea metadata format. NFTs and metadata views can be serialized by reference via contract methods.
 ///
+/// Special thanks to @austinkline for the idea and initial implementation & @bjartek + @bluesign for optimizations.
+///
 access(all) contract SerializeMetadata {
 
     /// Serializes the metadata (as a JSON compatible String) for a given NFT according to formats expected by EVM

--- a/cadence/contracts/utils/SerializeMetadata.cdc
+++ b/cadence/contracts/utils/SerializeMetadata.cdc
@@ -123,7 +123,7 @@ access(all) contract SerializeMetadata {
         // Serialize each trait as an attribute, building the serialized JSON compatible string
         let parts: [String] = []
         let traitsLength = traits.traits.length
-        for i, trait in traits.traits {
+        for trait in traits.traits {
             let attribute = self.serializeNFTTraitAsAttribute(trait)
             if attribute == nil {
                 continue

--- a/cadence/contracts/utils/SerializeMetadata.cdc
+++ b/cadence/contracts/utils/SerializeMetadata.cdc
@@ -31,14 +31,15 @@ access(all) contract SerializeMetadata {
         // Serialize the display values from the NFT's Display & NFTCollectionDisplay views
         let nftDisplay = nft.resolveView(Type<MetadataViews.Display>()) as! MetadataViews.Display?
         let collectionDisplay = nft.resolveView(Type<MetadataViews.NFTCollectionDisplay>()) as! MetadataViews.NFTCollectionDisplay?
+        // Serialize the display & collection display views - nil if both views are nil
         let display = self.serializeFromDisplays(nftDisplay: nftDisplay, collectionDisplay: collectionDisplay)
 
         // Get the Traits view from the NFT, returning early if no traits are found
         let traits = nft.resolveView(Type<MetadataViews.Traits>()) as! MetadataViews.Traits?
         let attributes = self.serializeNFTTraitsAsAttributes(traits ?? MetadataViews.Traits([]))
 
-        // Return an empty string if nothing is serializable
-        if display == nil && attributes == nil {
+        // Return an empty string if all views are nil
+        if display == nil && traits == nil {
             return ""
         }
         // Init the data format prefix & concatenate the serialized display & attributes

--- a/cadence/tests/serialize_metadata_tests.cdc
+++ b/cadence/tests/serialize_metadata_tests.cdc
@@ -74,7 +74,6 @@ fun testSerializeNFTSucceeds() {
     Test.expect(serializeMetadataResult, Test.beSucceeded())
 
     let serializedMetadata = serializeMetadataResult.returnValue! as! String
-
     Test.assertEqual(true, serializedMetadata == expectedPrefix.concat(altSuffix1) || serializedMetadata == expectedPrefix.concat(altSuffix2))
 }
 

--- a/cadence/tests/serialize_metadata_tests.cdc
+++ b/cadence/tests/serialize_metadata_tests.cdc
@@ -56,9 +56,10 @@ fun testSerializeNFTSucceeds() {
     mintedBlockHeight = heightResult.returnValue! as! UInt64
     let heightString = mintedBlockHeight.toString()
 
+    // Cadence dictionaries are not ordered by insertion order, so we need to check for both possible orderings
     let expectedPrefix = "data:application/json;utf8,{\"name\": \"ExampleNFT\", \"description\": \"Example NFT Collection\", \"image\": \"https://flow.com/examplenft.jpg\", \"external_url\": \"https://example-nft.onflow.org\", "
-    let altSuffix1 = "\"attributes\": [{\"trait_type\": \"mintedBlock\", \"value\": \"".concat(heightString).concat("\"},{\"trait_type\": \"foo\", \"value\": \"nil\"}]}")
-    let altSuffix2 = "\"attributes\": [{\"trait_type\": \"foo\", \"value\": \"nil\"}]}, {\"trait_type\": \"mintedBlock\", \"value\": \"".concat(heightString).concat("\"}")
+    let altSuffix1 = "\"attributes\": [{\"trait_type\": \"mintedBlock\", \"value\": \"".concat(heightString).concat("\"}, {\"trait_type\": \"foo\", \"value\": \"nil\"}]}")
+    let altSuffix2 = "\"attributes\": [{\"trait_type\": \"foo\", \"value\": \"nil\"}, {\"trait_type\": \"mintedBlock\", \"value\": \"".concat(heightString).concat("\"}]}")
 
     let idsResult = executeScript(
         "../scripts/nft/get_ids.cdc",

--- a/cadence/tests/serialize_tests.cdc
+++ b/cadence/tests/serialize_tests.cdc
@@ -239,6 +239,7 @@ fun testDictToJSONStringSucceeds() {
     var expectedTwo: String = "{\"arr\": [\"127\", \"Hello, World!\"], \"bool\": \"true\"}"
     
     var actual: String? = Serialize.dictToJSONString(dict: dict, excludedNames: nil)
+    log(actual)
     Test.assertEqual(true, expectedOne == actual! || expectedTwo == actual!)
     
     actual = Serialize.tryToJSONString(dict)

--- a/cadence/tests/serialize_tests.cdc
+++ b/cadence/tests/serialize_tests.cdc
@@ -239,7 +239,6 @@ fun testDictToJSONStringSucceeds() {
     var expectedTwo: String = "{\"arr\": [\"127\", \"Hello, World!\"], \"bool\": \"true\"}"
     
     var actual: String? = Serialize.dictToJSONString(dict: dict, excludedNames: nil)
-    log(actual)
     Test.assertEqual(true, expectedOne == actual! || expectedTwo == actual!)
     
     actual = Serialize.tryToJSONString(dict)

--- a/flow.json
+++ b/flow.json
@@ -264,7 +264,6 @@
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "e467b9dd11fa00df",
-				"previewnet": "b6763b4399a888c8",
 				"testnet": "8c5303eaa26202d6"
 			}
 		},
@@ -274,7 +273,6 @@
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "e467b9dd11fa00df",
-				"previewnet": "b6763b4399a888c8",
 				"testnet": "8c5303eaa26202d6"
 			}
 		},
@@ -284,7 +282,6 @@
 			"aliases": {
 				"emulator": "0ae53cb6e3f42a79",
 				"mainnet": "1654653399040a61",
-				"previewnet": "4445e7ad11568276",
 				"testnet": "7e60df042a9c0868"
 			}
 		},
@@ -294,7 +291,6 @@
 			"aliases": {
 				"emulator": "ee82856bf20e2aa6",
 				"mainnet": "f233dcee88fe0abe",
-				"previewnet": "a0225e7000ac82a9",
 				"testnet": "9a0766d93b6608b7"
 			}
 		},
@@ -304,7 +300,6 @@
 			"aliases": {
 				"emulator": "ee82856bf20e2aa6",
 				"mainnet": "f233dcee88fe0abe",
-				"previewnet": "a0225e7000ac82a9",
 				"testnet": "9a0766d93b6608b7"
 			}
 		},
@@ -314,7 +309,6 @@
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1d7e57aa55817448",
-				"previewnet": "b6763b4399a888c8",
 				"testnet": "631e88ae7f1d7c20"
 			}
 		},
@@ -324,7 +318,6 @@
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1d7e57aa55817448",
-				"previewnet": "b6763b4399a888c8",
 				"testnet": "631e88ae7f1d7c20"
 			}
 		},
@@ -334,7 +327,6 @@
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1d7e57aa55817448",
-				"previewnet": "b6763b4399a888c8",
 				"testnet": "631e88ae7f1d7c20"
 			}
 		}


### PR DESCRIPTION
Related: #80 

## Description

- Updates `Serialize.cdc` & `SerializeMetadata.cdc` by replacing `.concat` with `String.join` <- credit to @bluesign for the suggestion
  - See these transactions comparing [`.concat` (2167 gas)](https://testnet.flowdiver.io/tx/6ccf2b046f2431e1c7a72c54f882e076ce41fdd2a4e89d927bada1cbe9323d90) and [`String.join` (7 gas)](https://testnet.flowdiver.io/tx/1ae87d34fe73b99ae9e3c925911f9f8a07df54b89bcf24a8c556fd6a9788f163) to join 500 strings without looping
- Removes `previewnet` from `flow.json`

______

For contributor use:

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 