### PR TITLE
Follow up removal of CadenceBlocklist init

### DIFF
--- a/cadence/contracts/bridge/FlowEVMBridgeConfig.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeConfig.cdc
@@ -306,15 +306,6 @@ contract FlowEVMBridgeConfig {
         }
     }
 
-    access(all) fun initCadenceBlocklist() {
-        let cadenceBlocklistStoragePath = /storage/cadenceBlocklist
-        assert(
-            self.account.storage.type(at: cadenceBlocklistStoragePath) == nil,
-            message: "CadenceBlocklist already stored"
-        )
-        self.account.storage.save(<-create CadenceBlocklist(), to: cadenceBlocklistStoragePath)
-    }
-
     /// CadenceBlocklist resource stores a mapping of Cadence Types that are blocked from onboarding to the bridge
     ///
     access(all) resource CadenceBlocklist {

--- a/cadence/transactions/bridge/admin/blocklist/init_cadence_blocklist.cdc
+++ b/cadence/transactions/bridge/admin/blocklist/init_cadence_blocklist.cdc
@@ -1,9 +1,0 @@
-import "FlowEVMBridgeConfig"
-
-transaction {
-    prepare(signer: &Account) {}
-
-    execute {
-        FlowEVMBridgeConfig.initCadenceBlocklist()       
-    }
-}


### PR DESCRIPTION
## Description

- Removes the CadenceBlocklist initialization method from FlowEVMBridgeConfig
______

For contributor use:

- [x] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 