### PR TITLE
Remove `Locker.erc721Address` resource field

### DIFF
--- a/.github/workflows/cadence_test.yml
+++ b/.github/workflows/cadence_test.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: "1.23.x"
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/cadence/contracts/bridge/FlowEVMBridgeNFTEscrow.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeNFTEscrow.cdc
@@ -86,7 +86,7 @@ access(all) contract FlowEVMBridgeNFTEscrow {
     access(account)
     fun isEscrowInitialized(forType: Type): Bool {
         let lockerPath = FlowEVMBridgeUtils.deriveEscrowStoragePath(fromType: forType)
-            ?? panic("Problem deriving Locker path for NFT type identifier=".concat(forType.identifier))
+            ?? panic("Problem deriving Locker path for NFT type identifier=\(forType.identifier)")
         return self.account.storage.type(at: lockerPath) != nil
     }
 
@@ -94,10 +94,11 @@ access(all) contract FlowEVMBridgeNFTEscrow {
     ///
     access(account) fun initializeEscrow(forType: Type, name: String, symbol: String, erc721Address: EVM.EVMAddress) {
         let lockerPath = FlowEVMBridgeUtils.deriveEscrowStoragePath(fromType: forType)
-            ?? panic("Problem deriving Locker path for NFT type identifier=".concat(forType.identifier))
-        if self.account.storage.type(at: lockerPath) != nil {
-            panic("NFT Locker already stored at storage path=".concat(lockerPath.toString()))
-        }
+            ?? panic("Problem deriving Locker path for NFT type identifier=\(forType.identifier)")
+        assert(
+            self.account.storage.type(at: lockerPath) == nil,
+            message: "NFT Locker already stored at storage path=\(lockerPath.toString())"
+        )
 
         let locker <- create Locker(name: name, symbol: symbol, lockedType: forType)
         self.account.storage.save(<-locker, to: lockerPath)
@@ -107,7 +108,7 @@ access(all) contract FlowEVMBridgeNFTEscrow {
     ///
     access(account) fun lockNFT(_ nft: @{NonFungibleToken.NFT}): UInt64 {
         let locker = self.borrowLocker(forType: nft.getType())
-            ?? panic("Problem borrowing reference to Locker for NFT type identifier=".concat(nft.getType().identifier))
+            ?? panic("Problem borrowing reference to Locker for NFT type identifier=\(nft.getType().identifier)")
 
         let preStorageSnapshot = self.account.storage.used
         locker.deposit(token: <-nft)
@@ -127,7 +128,7 @@ access(all) contract FlowEVMBridgeNFTEscrow {
     ///
     access(account) fun unlockNFT(type: Type, id: UInt64): @{NonFungibleToken.NFT} {
         let locker = self.borrowLocker(forType: type)
-            ?? panic("Problem borrowing reference to Locker for NFT type identifier=".concat(type.identifier))
+            ?? panic("Problem borrowing reference to Locker for NFT type identifier=\(type.identifier)")
         return <- locker.withdraw(withdrawID: id)
     }
 
@@ -281,8 +282,7 @@ access(all) contract FlowEVMBridgeNFTEscrow {
         fun deposit(token: @{NonFungibleToken.NFT}) {
             pre {
                 self.borrowNFT(token.id) == nil:
-                "NFT type=".concat(token.getType().identifier).concat(" with id=").concat(token.id.toString())
-                    .concat(" already exists in the Locker")
+                "NFT type=\(token.getType().identifier) with id=\(token.id.toString()) already exists in the Locker"
             }
             if let evmID = CrossVMNFT.getEVMID(from: &token as &{NonFungibleToken.NFT}) {
                 self.evmIDToFlowID[evmID] = token.id
@@ -298,8 +298,7 @@ access(all) contract FlowEVMBridgeNFTEscrow {
             // Should not happen, but prevent potential underflow
             assert(
                 self.lockedNFTCount > 0,
-                message: "Attempting to withdraw NFT id=".concat(withdrawID.toString())
-                .concat(" - no NFTs of type=").concat(self.lockedType.identifier).concat(" to withdraw")
+                message: "Attempting to withdraw NFT id=\(withdrawID.toString()) - no NFTs of type=\(self.lockedType.identifier) to withdraw"
             )
             self.lockedNFTCount = self.lockedNFTCount - 1
             let token <- self.ownedNFTs.remove(key: withdrawID)!


### PR DESCRIPTION
Related: #146 

## Description

- Removes the unused `FlowEVMBridgeNFTEscrow.Locker.erc721Address` field which could be an invalid source of truth for NFTs that update their cross-VM implementation.
- Updates string derivation to use the new Cadence string interpolation feature instead of `.concat`.

______

For contributor use:

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 