### PR TITLE
Include custom associations in un/pause by Type functionality

### DIFF
--- a/cadence/contracts/bridge/FlowEVMBridgeConfig.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeConfig.cdc
@@ -105,13 +105,10 @@ contract FlowEVMBridgeConfig {
     ///
     access(all)
     view fun isTypePaused(_ type: Type): Bool? {
-        if !self.typeHasTokenHandler(type) {
-            // Most all assets will fall into this block - check if the asset is onboarded and paused
-            return self.registeredTypes[type]?.isPaused ?? nil
-        }
-        let customConfigStatus = FlowEVMBridgeCustomAssociations.isCustomConfigPaused(forType: type) ?? false
-        // If the asset has a TokenHandler, return true if either the Handler is paused or the type is paused
-        return self.borrowTokenHandler(type)!.isEnabled() == false || customConfigStatus || self.registeredTypes[type]?.isPaused == true
+        // Paused if the type has a token handler & it's disabled, a custom config has been paused or the bridge config has been paused
+        return !(self.borrowTokenHandler(type)?.isEnabled() ?? true)
+            || FlowEVMBridgeCustomAssociations.isCustomConfigPaused(forType: type) ?? false
+            || self.registeredTypes[type]?.isPaused == true
     }
 
     /// Retrieves the EVMAddress associated with a given Type if it has been onboarded to the bridge

--- a/cadence/contracts/bridge/FlowEVMBridgeConfig.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeConfig.cdc
@@ -474,7 +474,7 @@ contract FlowEVMBridgeConfig {
         fun pauseType(_ type: Type) {
             pre {
                 FlowEVMBridgeConfig.getEVMAddressAssociated(with: type) != nil || FlowEVMBridgeCustomAssociations.getEVMAddressAssociated(with: type) != nil:
-                "Could not find an a bridged or custom association for type \(type.identifier) - cannot pause a type without an association"
+                "Could not find a bridged or custom association for type \(type.identifier) - cannot pause a type without an association"
             }
             FlowEVMBridgeConfig.updatePauseStatus(type, pause: true)
         }
@@ -489,7 +489,7 @@ contract FlowEVMBridgeConfig {
         fun unpauseType(_ type: Type) {
             pre {
                 FlowEVMBridgeConfig.getEVMAddressAssociated(with: type) != nil || FlowEVMBridgeCustomAssociations.getEVMAddressAssociated(with: type) != nil:
-                "Could not find an a bridged or custom association for type \(type.identifier) - cannot unpause a type without an association"
+                "Could not find a bridged or custom association for type \(type.identifier) - cannot unpause a type without an association"
             }
             FlowEVMBridgeConfig.updatePauseStatus(type, pause: false)
         }

--- a/cadence/contracts/bridge/FlowEVMBridgeConfig.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeConfig.cdc
@@ -279,9 +279,8 @@ contract FlowEVMBridgeConfig {
                 }
             }
         }
-        if evmAddress.length == 0 {
-            panic("There was no association found for type \(type.identifier). To block the type from onboarding, use the CadenceBlocklist.")
-        }
+        assert(evmAddress.length == 0,
+            message: "There was no association found for type \(type.identifier). To block the type from onboarding, use the CadenceBlocklist.")
         emit AssetPauseStatusUpdated(paused: pause, type: type.identifier, evmAddress: evmAddress)
     }
 

--- a/cadence/contracts/bridge/FlowEVMBridgeConfig.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeConfig.cdc
@@ -109,8 +109,9 @@ contract FlowEVMBridgeConfig {
             // Most all assets will fall into this block - check if the asset is onboarded and paused
             return self.registeredTypes[type]?.isPaused ?? nil
         }
+        let customConfigStatus = FlowEVMBridgeCustomAssociations.isCustomConfigPaused(forType: type) ?? false
         // If the asset has a TokenHandler, return true if either the Handler is paused or the type is paused
-        return self.borrowTokenHandler(type)!.isEnabled() == false || self.registeredTypes[type]?.isPaused == true
+        return self.borrowTokenHandler(type)!.isEnabled() == false || customConfigStatus || self.registeredTypes[type]?.isPaused == true
     }
 
     /// Retrieves the EVMAddress associated with a given Type if it has been onboarded to the bridge

--- a/cadence/contracts/bridge/FlowEVMBridgeCustomAssociations.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeCustomAssociations.cdc
@@ -115,6 +115,22 @@ access(all) contract FlowEVMBridgeCustomAssociations {
         self.associationsConfig[type] <-! config
     }
 
+    access(account) fun pauseCustomConfig(forType: Type) {
+        let config = self.borrowNFTCustomConfig(forType: forType)
+            ?? panic("No CustomConfig found for type \(forType.identifier) - cannot pause config that does not exist")
+        if config.isPaused() {
+            config.setPauseStatus(true)
+        }
+    }
+
+    access(account) fun unpauseCustomConfig(forType: Type) {
+        let config = self.borrowNFTCustomConfig(forType: forType)
+            ?? panic("No CustomConfig found for type \(forType.identifier) - cannot unpause config that does not exist")
+        if config.isPaused() {
+            config.setPauseStatus(false)
+        }
+    }
+
     /// Returns a reference to the NFTCustomConfig if it exists, nil otherwise
     ///
     access(self)

--- a/cadence/contracts/bridge/FlowEVMBridgeCustomAssociations.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeCustomAssociations.cdc
@@ -33,6 +33,8 @@ access(all) contract FlowEVMBridgeCustomAssociations {
     ///
     /// @param with: The Cadence Type to query against
     ///
+    /// @return The EVM address configured as associated with the provided Cadence Type
+    ///
     access(all)
     view fun getEVMAddressAssociated(with type: Type): EVM.EVMAddress? {
         return self.associationsConfig[type]?.getEVMContractAddress() ?? nil
@@ -42,6 +44,8 @@ access(all) contract FlowEVMBridgeCustomAssociations {
     ///
     /// @param with: The EVM contract address to query against
     ///
+    /// @return The Cadence Type configured as associated with the provided EVM address
+    ///
     access(all)
     view fun getTypeAssociated(with evmAddress: EVM.EVMAddress): Type? {
         return self.associationsByEVMAddress[evmAddress.toString()]
@@ -50,6 +54,8 @@ access(all) contract FlowEVMBridgeCustomAssociations {
     /// Returns an EVMPointer containing the data at the time of registration
     ///
     /// @param forType: The Cadence Type to query against
+    ///
+    /// @return a copy of the EVMPointer view as registered with the bridge
     ///
     access(all)
     fun getEVMPointerAsRegistered(forType: Type): CrossVMMetadataViews.EVMPointer? {
@@ -62,6 +68,19 @@ access(all) contract FlowEVMBridgeCustomAssociations {
             )
         }
         return nil
+    }
+
+    /// Returns whether the related CustomConfig is currently paused or not. `nil` is returned if a CustomConfig is not
+    /// found for the given Type
+    ///
+    /// @param forType: The Cadence Type for which to retrieve a registered CustomConfig
+    ///
+    /// @return true if the CustomConfig is paused, false if registered and unpaused, nil if unregistered as a custom
+    ///     association
+    ///
+    access(all)
+    view fun isCustomConfigPaused(forType: Type): Bool? {
+        return self.borrowNFTCustomConfig(forType: forType)?.isPaused() ?? nil
     }
 
     /// Allows the bridge contracts to preserve a custom association. Will revert if a custom association already exists


### PR DESCRIPTION
Closes: #172 

## Description

Include custom associations in pause & unpause by type functionality. Tests will be added once bridge routes have been updated to handle bridging custom cross-VM NFTs.

______

For contributor use:

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 