### PR TITLE
Fix dual-onboarded cross-VM registration edge case

### DIFF
--- a/cadence/contracts/bridge/FlowEVMBridge.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridge.cdc
@@ -292,8 +292,8 @@ contract FlowEVMBridge : IFlowEVMNFTBridge, IFlowEVMTokenBridge {
         /* Native VM consistency check */
         //
         // Assess if the NFT has been previously onboarded to the bridge
-        let legacyEVMAssoc = FlowEVMBridgeConfig.getEVMAddressAssociated(with: type)
-        let legacyCadenceAssoc = FlowEVMBridgeConfig.getTypeAssociated(with: evmPointer.evmContractAddress)
+        let legacyEVMAssoc = FlowEVMBridgeConfig.getLegacyEVMAddressAssociated(with: type)
+        let legacyCadenceAssoc = FlowEVMBridgeConfig.getLegacyTypeAssociated(with: evmPointer.evmContractAddress)
         assert(legacyEVMAssoc == nil || legacyCadenceAssoc == nil,
             message: "Both the EVM contract \(evmPointer.evmContractAddress.toString()) and the Cadence Type \(type.identifier) "
                 .concat("have already been onboarded to the VM bridge - one side of this association will have to be redeployed ")

--- a/cadence/contracts/bridge/FlowEVMBridge.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridge.cdc
@@ -294,20 +294,23 @@ contract FlowEVMBridge : IFlowEVMNFTBridge, IFlowEVMTokenBridge {
         // Assess if the NFT has been previously onboarded to the bridge
         let legacyEVMAssoc = FlowEVMBridgeConfig.getEVMAddressAssociated(with: type)
         let legacyCadenceAssoc = FlowEVMBridgeConfig.getTypeAssociated(with: evmPointer.evmContractAddress)
+        assert(legacyEVMAssoc == nil || legacyCadenceAssoc == nil,
+            message: "Both the EVM contract \(evmPointer.evmContractAddress.toString()) and the Cadence Type \(type.identifier) "
+                .concat("have already been onboarded to the VM bridge - one side of this association will have to be redeployed ")
+                .concat("and the declared association updated to a non-onboarded target in order to register as a custom cross-VM asset."))
         // Ensure the native VM is consistent if the NFT has been previously onboarded via the permissionless path
-        if legacyEVMAssoc != nil && legacyCadenceAssoc == nil {
+        if legacyEVMAssoc != nil {
             assert(evmPointer.nativeVM == CrossVMMetadataViews.VM.Cadence,
                 message: "Attempting to register NFT \(type.identifier) as EVM-native after it has already been "
                     .concat("onboarded as Cadence-native. This NFT must be configured as Cadence-native with an ERC721 ")
                     .concat("implementing CrossVMBridgeERC721Fulfillment base contract allowing the bridge to fulfill ")
                     .concat("NFTs moving into EVM"))
-        } else if legacyEVMAssoc == nil && legacyCadenceAssoc != nil  {
+        } else if legacyCadenceAssoc != nil {
             assert(evmPointer.nativeVM == CrossVMMetadataViews.VM.EVM,
                 message: "Attempting to register NFT \(type.identifier) as Cadence-native after it has already been "
                     .concat("onboarded as EVM-native. This NFT must be configured as EVM-native and provide an NFTFulfillmentMinter ")
                     .concat("Capability so the bridge may fulfill NFTs moving into Cadence."))
         }
-        // Notably, the edge case where legacyEVMAssoc != nil && legacyCadenceAssoc != nil it omitted - default to project-declared native VM in this case
 
         FlowEVMBridgeCustomAssociations.saveCustomAssociation(
             type: type,


### PR DESCRIPTION
Closes: #177

## Description

- Prevents the cross-VM registration of associations where both the Cadence Type & EVM contract have already been onboarded to the bridge. This was seen as the best corrective action for such an edge case given the downstream assumptions about native-VM distribution and asset existence while fulfilling NFTs between VMs.
______

For contributor use:

- [x] Targeted PR against `flip318` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 