### PR TITLE
Enable Cadence NFTs to update their bridged ERC721 symbol

### DIFF
--- a/cadence/contracts/bridge/FlowEVMBridgeUtils.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeUtils.cdc
@@ -1554,6 +1554,21 @@ contract FlowEVMBridgeUtils {
         return decodedResult[0] as! EVM.EVMAddress
     }
 
+    /// Calls `setSymbol(string)` on the EVM contract as exposed on FlowEVMBridgedERC721 contracts, enabling Cadence
+    /// NFTs to update their EVM symbol via EVMBridgedMetadata.symbol. The call's status is returned so conditional 
+    /// execution can be handled on the caller's end.
+    ///
+    access(account)
+    fun tryUpdateSymbol(_ evmContractAddress: EVM.EVMAddress, symbol: String): Bool {
+        return self.call(
+            signature: "setSymbol(string)",
+            targetEVMAddress: evmContractAddress,
+            args: [symbol],
+            gasLimit: FlowEVMBridgeConfig.gasLimit,
+            value: 0.0
+        ).status == EVM.Status.successful
+    }
+
     init(bridgeFactoryAddressHex: String) {
         self.delimiter = "_"
         self.contractNamePrefixes = {


### PR DESCRIPTION
Closes: #117 

## Description

- Adds the ability for Cadence-native NFT projects with bridged ERC721 representation to update their EVM symbol by defining it in `EVMBridgedMetadata.symbol`. This process is executed when bridging to EVM.

______

For contributor use:

- [x] Targeted PR against `flip-318` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 