### PR TITLE
Adds full balance script

### DIFF
--- a/cadence/scripts/tokens/get_full_cadence_evm_balance.cdc
+++ b/cadence/scripts/tokens/get_full_cadence_evm_balance.cdc
@@ -1,0 +1,76 @@
+import "EVM"
+import "FungibleToken"
+import "FlowEVMBridgeUtils"
+import "FlowEVMBridgeConfig"
+import "FungibleTokenMetadataViews"
+
+/// Returns the balance of the owner of a given Fungible Token
+/// from their Cadence account and their COA
+///
+/// @param owner: The Flow address of the owner
+/// @param contractAddress: The address of the FT contract in Cadence
+/// @param contractName: The name of the FT contract in Cadence
+///
+/// @return The balance of the address, reverting if the given contract address does not implement the ERC20 method
+///     "balanceOf(address)(uint256)"
+///
+
+access(all) fun main(owner: Address, contractAddress: Address, contractName: String): UInt256 {
+    // Borrow a reference to the FT contract
+    let resolverRef = getAccount(contractAddress)
+        .contracts.borrow<&{FungibleToken}>(name: contractName)
+            ?? panic("Could not borrow FungibleToken reference to the contract. Make sure the provided contract name ("
+                        .concat(contractName).concat(") and address (").concat(contractAddress.toString()).concat(") are correct!"))
+
+    // Use that reference to retrieve the FTView 
+    let vaultData = resolverRef.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTVaultData>()) as! FungibleTokenMetadataViews.FTVaultData?
+        ?? panic("Could not resolve FTVaultData view. The ".concat(contractName)
+            .concat(" contract needs to implement the FTVaultData Metadata view in order to execute this transaction."))
+
+    // Get the Cadence balance of the token
+    let cadenceBalance = getAccount(owner).capabilities.borrow<&{FungibleToken.Balance}>(
+            vaultData.metadataPath
+        )?.balance
+        ?? panic("Could not borrow a balance reference to the FungibleToken Vault in account "
+                .concat(owner.toString()).concat(" at path ").concat(vaultData.metadataPath.toString())
+                .concat(". Make sure you are querying an address that has ")
+                .concat("a FungibleToken Vault set up properly at the specified path."))
+
+    // Get the COA from the owner's account
+    let coa = getAuthAccount<auth(BorrowValue) &Account>(owner)
+        .storage.borrow<auth(EVM.Call) &EVM.CadenceOwnedAccount>(
+            from: /storage/evm
+        ) ?? panic("Could not borrow COA from provided address")
+    // Get the COA address
+    let coaAddress = coa.address().toString()
+
+    let contractAddressWithoutHexPrefix = contractAddress.toString().slice(from: 2, upTo: 18)
+
+    // Get the EVM address of the bridged version of the Cadence FT contract
+    let typeIdentifier = "A.\(contractAddressWithoutHexPrefix).\(contractName).Vault"
+    var tokenEVMAddress = ""
+    if let type = CompositeType(typeIdentifier) {
+        if let address = FlowEVMBridgeConfig.getEVMAddressAssociated(with: type) {
+            tokenEVMAddress = address.toString()
+        } else {
+            panic("Could not get an EVM address from the provided type")
+        }
+    } else {
+        panic("Could not construct type with \(typeIdentifier)")
+    }
+
+    // Get the ERC20 balance of the COA
+    let coaBalance = FlowEVMBridgeUtils.balanceOf(
+        owner: EVM.addressFromString(coaAddress),
+        evmContractAddress: EVM.addressFromString(tokenEVMAddress)
+    )
+
+    // Get the token decimals of the ERC20 contract
+    let decimals = FlowEVMBridgeUtils.getTokenDecimals(
+        evmContractAddress: EVM.addressFromString(tokenEVMAddress)
+    )
+    // Convert the Cadence balance to UInt256
+    let cadenceBalanceUInt256 = FlowEVMBridgeUtils.ufix64ToUInt256(value: cadenceBalance, decimals: decimals)
+
+    return coaBalance + cadenceBalanceUInt256
+}

--- a/cadence/scripts/tokens/get_full_cadence_evm_balance.cdc
+++ b/cadence/scripts/tokens/get_full_cadence_evm_balance.cdc
@@ -6,71 +6,119 @@ import "FungibleTokenMetadataViews"
 
 /// Returns the balance of the owner of a given Fungible Token
 /// from their Cadence account and their COA
+/// Accepts multiple optional arguments, so the caller can query
+/// the token by its EVM ERC20 address or by its Cadence contract address and name
 ///
 /// @param owner: The Flow address of the owner
-/// @param contractAddress: The address of the FT contract in Cadence
-/// @param contractName: The name of the FT contract in Cadence
+/// @param contractAddressArg: The optional address of the FT contract in Cadence
+/// @param contractNameArg: The optional name of the FT contract in Cadence
+/// @param erc20AddressHex: The optional ERC20 address of the FT to query
 ///
-/// @return The balance of the address, reverting if the given contract address does not implement the ERC20 method
-///     "balanceOf(address)(uint256)"
+/// @return An array that contains the balance information for the user's accounts
+///         as UInt256 in this order:
+///         cadence Balance, EVM Balance, Total Balance
 ///
 
-access(all) fun main(owner: Address, contractAddress: Address, contractName: String): UInt256 {
-    // Borrow a reference to the FT contract
-    let resolverRef = getAccount(contractAddress)
-        .contracts.borrow<&{FungibleToken}>(name: contractName)
-            ?? panic("Could not borrow FungibleToken reference to the contract. Make sure the provided contract name ("
-                        .concat(contractName).concat(") and address (").concat(contractAddress.toString()).concat(") are correct!"))
-
-    // Use that reference to retrieve the FTView 
-    let vaultData = resolverRef.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTVaultData>()) as! FungibleTokenMetadataViews.FTVaultData?
-        ?? panic("Could not resolve FTVaultData view. The ".concat(contractName)
-            .concat(" contract needs to implement the FTVaultData Metadata view in order to execute this transaction."))
-
-    // Get the Cadence balance of the token
-    let cadenceBalance = getAccount(owner).capabilities.borrow<&{FungibleToken.Balance}>(
-            vaultData.metadataPath
-        )?.balance
-        ?? panic("Could not borrow a balance reference to the FungibleToken Vault in account "
-                .concat(owner.toString()).concat(" at path ").concat(vaultData.metadataPath.toString())
-                .concat(". Make sure you are querying an address that has ")
-                .concat("a FungibleToken Vault set up properly at the specified path."))
-
-    // Get the COA from the owner's account
-    let coa = getAuthAccount<auth(BorrowValue) &Account>(owner)
-        .storage.borrow<auth(EVM.Call) &EVM.CadenceOwnedAccount>(
-            from: /storage/evm
-        ) ?? panic("Could not borrow COA from provided address")
-    // Get the COA address
-    let coaAddress = coa.address().toString()
-
-    let contractAddressWithoutHexPrefix = contractAddress.toString().slice(from: 2, upTo: 18)
-
-    // Get the EVM address of the bridged version of the Cadence FT contract
-    let typeIdentifier = "A.\(contractAddressWithoutHexPrefix).\(contractName).Vault"
-    var tokenEVMAddress = ""
-    if let type = CompositeType(typeIdentifier) {
-        if let address = FlowEVMBridgeConfig.getEVMAddressAssociated(with: type) {
-            tokenEVMAddress = address.toString()
-        } else {
-            panic("Could not get an EVM address from the provided type")
-        }
-    } else {
-        panic("Could not construct type with \(typeIdentifier)")
+access(all) fun main(
+        owner: Address,
+        contractAddressArg: Address?,
+        contractNameArg: String?,
+        erc20AddressHexArg: String?
+): [UInt256] {
+    pre {
+        (contractAddressArg == nil && contractNameArg == nil) ||
+        (contractAddressArg != nil && contractNameArg != nil):
+            "The caller must either provide both the contract address and contract name or neither."
+        contractAddressArg == nil ? erc20AddressHexArg != nil : true:
+            "If the Cadence contract information is not provided, the ERC20 contract address must be provided."
     }
 
-    // Get the ERC20 balance of the COA
-    let coaBalance = FlowEVMBridgeUtils.balanceOf(
-        owner: EVM.addressFromString(coaAddress),
-        evmContractAddress: EVM.addressFromString(tokenEVMAddress)
-    )
+    var typeIdentifier: String? = nil
+    var compType: Type? = nil
+    var contractAddress: Address? = nil
+    var contractName: String? = nil
+    var tokenEVMAddress: String? = nil
+    var cadenceBalance: UFix64 = 0.0
+    var cadenceBalanceUInt256: UInt256 = 0
+    var coaBalance: UInt256 = 0
+    
+    // If the caller provided the Cadence information,
+    // Construct the composite type
+    if contractAddressArg != nil {
+        contractAddress = contractAddressArg!
+        contractName = contractNameArg!
+        let contractAddressWithoutHexPrefix = contractAddress!.toString().slice(from: 2, upTo: 18)
+        typeIdentifier = "A.\(contractAddressWithoutHexPrefix).\(contractName!).Vault"
+        compType = CompositeType(typeIdentifier!)
+        // Get the EVM address of the bridged version of the Cadence FT contract
+        if let type = compType {
+            if let address = FlowEVMBridgeConfig.getEVMAddressAssociated(with: type) {
+                tokenEVMAddress = address.toString()
+            }
+        } else {
+            panic("Could not construct Cadence type with \(typeIdentifier!)")
+        }
+    } else {
+        // If the caller provided the EVM information,
+        // get the Cadence type from the bridge
+        // If getting the Cadence type doesn't work, then we'll just return the EVM balance
+        tokenEVMAddress = erc20AddressHexArg!
+        let address = EVM.addressFromString(tokenEVMAddress!)
+        compType = FlowEVMBridgeConfig.getTypeAssociated(with: address)
+        typeIdentifier = compType?.identifier
+        if typeIdentifier != nil {
+            let splitIdentifier = typeIdentifier!.split(separator: ".")
+            contractAddress = Address.fromString(splitIdentifier[1])
+            contractName = splitIdentifier[2]
+        }
+    }
 
-    // Get the token decimals of the ERC20 contract
-    let decimals = FlowEVMBridgeUtils.getTokenDecimals(
-        evmContractAddress: EVM.addressFromString(tokenEVMAddress)
-    )
-    // Convert the Cadence balance to UInt256
-    let cadenceBalanceUInt256 = FlowEVMBridgeUtils.ufix64ToUInt256(value: cadenceBalance, decimals: decimals)
+    if let address = contractAddress {
+        // Borrow a reference to the FT contract
+        let resolverRef = getAccount(address)
+            .contracts.borrow<&{FungibleToken}>(name: contractName!)
+                ?? panic("Could not borrow FungibleToken reference to the contract. Make sure the provided contract name ("
+                            .concat(contractName!).concat(") and address (").concat(address.toString()).concat(") are correct!"))
 
-    return coaBalance + cadenceBalanceUInt256
+        // Use that reference to retrieve the FTView 
+        let vaultData = resolverRef.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTVaultData>()) as! FungibleTokenMetadataViews.FTVaultData?
+            ?? panic("Could not resolve FTVaultData view. The ".concat(contractName!)
+                .concat(" contract needs to implement the FTVaultData Metadata view in order to execute this transaction."))
+
+        // Get the Cadence balance of the token
+        cadenceBalance = getAccount(owner).capabilities.borrow<&{FungibleToken.Balance}>(
+                vaultData.metadataPath
+            )?.balance
+            ?? 0.0
+    }
+
+    // Get the COA from the owner's account
+    if let coa = getAuthAccount<auth(BorrowValue) &Account>(owner)
+        .storage.borrow<auth(EVM.Call) &EVM.CadenceOwnedAccount>(
+            from: /storage/evm
+        ) 
+    {
+        if let erc20Address = tokenEVMAddress {
+            // Get the COA address
+            let coaAddress = coa.address().toString()
+
+            // Get the ERC20 balance of the COA
+            coaBalance = FlowEVMBridgeUtils.balanceOf(
+                owner: EVM.addressFromString(coaAddress),
+                evmContractAddress: EVM.addressFromString(erc20Address)
+            )
+
+            // Get the token decimals of the ERC20 contract
+            let decimals = FlowEVMBridgeUtils.getTokenDecimals(
+                evmContractAddress: EVM.addressFromString(erc20Address)
+            )
+
+            // Convert the Cadence balance to UInt256
+            cadenceBalanceUInt256 = FlowEVMBridgeUtils.ufix64ToUInt256(value: cadenceBalance, decimals: decimals)
+        }
+    }
+
+    let balances = [cadenceBalanceUInt256, coaBalance, cadenceBalanceUInt256+coaBalance]
+    
+    return balances
 }

--- a/cadence/tests/flow_evm_bridge_tests.cdc
+++ b/cadence/tests/flow_evm_bridge_tests.cdc
@@ -1031,9 +1031,9 @@ fun testBridgeCadenceNativeTokenToEVMSucceeds() {
     let expectedTotalBalance = ufix64ToUInt256(exampleTokenMintAmount, decimals: decimals)
 
     var completeBalances = getFullBalance(ownerAddr: alice.address, vaultIdentifier: exampleTokenIdentifier, erc20AddressHex: nil)
-    Test.assert(completeBalances[0] == expectedTotalBalance)
-    Test.assert(completeBalances[1] == 0)
-    Test.assert(completeBalances[2] == expectedTotalBalance)
+    Test.assert(completeBalances[1] as! UFix64 == exampleTokenMintAmount)
+    Test.assert(completeBalances[2] as! UInt256 == 0)
+    Test.assert(completeBalances[3] as! UInt256 == expectedTotalBalance)
 
     var aliceCOAAddressHex = getCOAAddressHex(atFlowAddress: alice.address)
 
@@ -1064,15 +1064,15 @@ fun testBridgeCadenceNativeTokenToEVMSucceeds() {
     // Confirm complete balance is still the same,
     // this time querying with the erc20 address
     completeBalances = getFullBalance(ownerAddr: alice.address, vaultIdentifier: nil, erc20AddressHex: associatedEVMAddressHex)
-    Test.assert(completeBalances[0] == 0)
-    Test.assert(completeBalances[1] == expectedTotalBalance)
-    Test.assert(completeBalances[2] == expectedTotalBalance)
+    Test.assert(completeBalances[1] as! UFix64 == 0.0)
+    Test.assert(completeBalances[2] as! UInt256 == expectedTotalBalance)
+    Test.assert(completeBalances[3] as! UInt256 == expectedTotalBalance)
 
     // Query an account without the token to make sure balances are zero
     completeBalances = getFullBalance(ownerAddr: bob.address, vaultIdentifier: nil, erc20AddressHex: associatedEVMAddressHex)
-    Test.assert(completeBalances[0] == 0)
-    Test.assert(completeBalances[1] == 0)
-    Test.assert(completeBalances[2] == 0)
+    Test.assert(completeBalances[1] as! UFix64 == 0.0)
+    Test.assert(completeBalances[2] as! UInt256 == 0)
+    Test.assert(completeBalances[3] as! UInt256 == 0)
 }
 
 access(all)

--- a/cadence/tests/flow_evm_bridge_tests.cdc
+++ b/cadence/tests/flow_evm_bridge_tests.cdc
@@ -1030,7 +1030,7 @@ fun testBridgeCadenceNativeTokenToEVMSucceeds() {
     let decimals = getTokenDecimals(erc20AddressHex: associatedEVMAddressHex)
     let expectedTotalBalance = ufix64ToUInt256(exampleTokenMintAmount, decimals: decimals)
 
-    var completeBalances = getFullBalance(ownerAddr: alice.address, contractAddress: 0x0000000000000010, contractName: "ExampleToken", erc20AddressHex: nil)
+    var completeBalances = getFullBalance(ownerAddr: alice.address, vaultIdentifier: exampleTokenIdentifier, erc20AddressHex: nil)
     Test.assert(completeBalances[0] == expectedTotalBalance)
     Test.assert(completeBalances[1] == 0)
     Test.assert(completeBalances[2] == expectedTotalBalance)
@@ -1063,13 +1063,13 @@ fun testBridgeCadenceNativeTokenToEVMSucceeds() {
 
     // Confirm complete balance is still the same,
     // this time querying with the erc20 address
-    completeBalances = getFullBalance(ownerAddr: alice.address, contractAddress: nil, contractName: nil, erc20AddressHex: associatedEVMAddressHex)
+    completeBalances = getFullBalance(ownerAddr: alice.address, vaultIdentifier: nil, erc20AddressHex: associatedEVMAddressHex)
     Test.assert(completeBalances[0] == 0)
     Test.assert(completeBalances[1] == expectedTotalBalance)
     Test.assert(completeBalances[2] == expectedTotalBalance)
 
     // Query an account without the token to make sure balances are zero
-    completeBalances = getFullBalance(ownerAddr: bob.address, contractAddress: nil, contractName: nil, erc20AddressHex: associatedEVMAddressHex)
+    completeBalances = getFullBalance(ownerAddr: bob.address, vaultIdentifier: nil, erc20AddressHex: associatedEVMAddressHex)
     Test.assert(completeBalances[0] == 0)
     Test.assert(completeBalances[1] == 0)
     Test.assert(completeBalances[2] == 0)

--- a/cadence/tests/test_helpers.cdc
+++ b/cadence/tests/test_helpers.cdc
@@ -350,13 +350,13 @@ fun getFullBalance(
     ownerAddr: Address,
     vaultIdentifier: String?,
     erc20AddressHex: String?
-): [UInt256] {
+): [AnyStruct] {
     let balanceResult = _executeScript(
         "../scripts/tokens/get_full_cadence_evm_balance.cdc",
         [ownerAddr, vaultIdentifier, erc20AddressHex]
     )
     Test.expect(balanceResult, Test.beSucceeded())
-    return balanceResult.returnValue as! [UInt256]
+    return balanceResult.returnValue as! [AnyStruct]
 }
 
 access(all)

--- a/cadence/tests/test_helpers.cdc
+++ b/cadence/tests/test_helpers.cdc
@@ -346,6 +346,16 @@ fun getBalance(ownerAddr: Address, storagePathIdentifier: String): UFix64? {
 }
 
 access(all)
+fun getFullBalance(ownerAddr: Address, contractAddress: Address, contractName: String): UInt256? {
+    let balanceResult = _executeScript(
+        "../scripts/tokens/get_full_cadence_evm_balance.cdc",
+        [ownerAddr, contractAddress, contractName]
+    )
+    Test.expect(balanceResult, Test.beSucceeded())
+    return balanceResult.returnValue as! UInt256?
+}
+
+access(all)
 fun balanceOf(evmAddressHex: String, erc20AddressHex: String): UInt256 {
     let balanceOfResult = _executeScript(
         "../scripts/utils/balance_of.cdc",

--- a/cadence/tests/test_helpers.cdc
+++ b/cadence/tests/test_helpers.cdc
@@ -346,13 +346,18 @@ fun getBalance(ownerAddr: Address, storagePathIdentifier: String): UFix64? {
 }
 
 access(all)
-fun getFullBalance(ownerAddr: Address, contractAddress: Address, contractName: String): UInt256? {
+fun getFullBalance(
+    ownerAddr: Address,
+    contractAddress: Address?,
+    contractName: String?,
+    erc20AddressHex: String?
+): [UInt256] {
     let balanceResult = _executeScript(
         "../scripts/tokens/get_full_cadence_evm_balance.cdc",
-        [ownerAddr, contractAddress, contractName]
+        [ownerAddr, contractAddress, contractName, erc20AddressHex]
     )
     Test.expect(balanceResult, Test.beSucceeded())
-    return balanceResult.returnValue as! UInt256?
+    return balanceResult.returnValue as! [UInt256]
 }
 
 access(all)

--- a/cadence/tests/test_helpers.cdc
+++ b/cadence/tests/test_helpers.cdc
@@ -348,13 +348,12 @@ fun getBalance(ownerAddr: Address, storagePathIdentifier: String): UFix64? {
 access(all)
 fun getFullBalance(
     ownerAddr: Address,
-    contractAddress: Address?,
-    contractName: String?,
+    vaultIdentifier: String?,
     erc20AddressHex: String?
 ): [UInt256] {
     let balanceResult = _executeScript(
         "../scripts/tokens/get_full_cadence_evm_balance.cdc",
-        [ownerAddr, contractAddress, contractName, erc20AddressHex]
+        [ownerAddr, vaultIdentifier, erc20AddressHex]
     )
     Test.expect(balanceResult, Test.beSucceeded())
     return balanceResult.returnValue as! [UInt256]

--- a/flow.json
+++ b/flow.json
@@ -334,7 +334,7 @@
 		},
 		"FungibleToken": {
 			"source": "mainnet://f233dcee88fe0abe.FungibleToken",
-			"hash": "050328d01c6cde307fbe14960632666848d9b7ea4fef03ca8c0bbfb0f2884068",
+			"hash": "23c1159cf99b2b039b6b868d782d57ae39b8d784045d81597f100a4782f0285b",
 			"aliases": {
 				"emulator": "ee82856bf20e2aa6",
 				"mainnet": "f233dcee88fe0abe",

--- a/flow.json
+++ b/flow.json
@@ -433,6 +433,11 @@
 		}
 	},
 	"deployments": {
+		"emulator": {
+			"emulator-account": [
+				"CrossVMMetadataViews"
+			]
+		},
 		"mainnet": {
 			"mainnet-flow-evm-bridge": [
 				"FlowEVMBridgeHandlerInterfaces",


### PR DESCRIPTION
Works towards https://github.com/onflow/fcl-js/issues/2355

## Description

Adds a script that gets the combined Cadence and COA balance of an account for a specific fungible token, specified by Cadence account address and contract name.

______

For contributor use:

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [x] Re-reviewed `Files changed` in the Github PR explorer