### PR TITLE
Updates batch bridge transactions to also execute arbitrary calls

### DIFF
--- a/cadence/tests/flow_evm_bridge_tests.cdc
+++ b/cadence/tests/flow_evm_bridge_tests.cdc
@@ -490,6 +490,23 @@ fun testOnboardAndBridgeTokensToEVMSucceeds() {
 }
 
 access(all)
+fun testBridgeTokensToEVMandTxsSucceeds() {
+    // Revert to state before ExampleNFT was onboarded
+    Test.reset(to: snapshot)
+
+    var cadenceBalance = getBalance(ownerAddr: alice.address, storagePathIdentifier: "exampleTokenVault")
+        ?? panic("Could not get ExampleToken balance")
+
+    // Execute bridge to EVM - should also onboard the token type
+    let bridgeResult = executeTransaction(
+        "../transactions/bridge/tokens/bridge_tokens_to_evm_and_txs.cdc",
+        [ exampleTokenIdentifier, cadenceBalance, [], [], [], []],
+        alice
+    )
+    Test.expect(bridgeResult, Test.beSucceeded())
+}
+
+access(all)
 fun testOnboardAndCrossVMTransferTokensToEVMSucceeds() {
     // Revert to state before ExampleNFT was onboarded
     Test.reset(to: snapshot)
@@ -762,7 +779,7 @@ fun testBatchBridgeCadenceNativeNFTToEVMSucceeds() {
     // Execute bridge to EVM
     let bridgeResult = executeTransaction(
         "../transactions/bridge/nft/batch_bridge_nft_to_evm.cdc",
-        [ exampleNFTIdentifier, aliceOwnedIDs, [], [], [], [] ],
+        [ exampleNFTIdentifier, aliceOwnedIDs ],
         alice
     )
     Test.expect(bridgeResult, Test.beSucceeded())
@@ -789,6 +806,26 @@ fun testBatchBridgeCadenceNativeNFTToEVMSucceeds() {
     let metadata2 = resolveLockedNFTView(bridgeAddress: bridgeAccount.address, nftTypeIdentifier: exampleNFTIdentifier, id: UInt256(mintedNFTID2), viewIdentifier: Type<MetadataViews.Display>().identifier)
     Test.assert(metadata1 != nil, message: "Expected NFT metadata to be resolved from escrow but none was returned")
     Test.assert(metadata2 != nil, message: "Expected NFT metadata to be resolved from escrow but none was returned")
+}
+
+access(all)
+fun testBatchBridgeCadenceNativeNFTToEVMAndTxsSucceeds() {
+    let tmp = snapshot
+    Test.reset(to: snapshot)
+    snapshot = tmp
+
+    var aliceOwnedIDs = getIDs(ownerAddr: alice.address, storagePathIdentifier: "cadenceExampleNFTCollection")
+    Test.assertEqual(2, aliceOwnedIDs.length)
+
+    var aliceCOAAddressHex = getCOAAddressHex(atFlowAddress: alice.address)
+
+    // Execute bridge to EVM
+    let bridgeResult = executeTransaction(
+        "../transactions/bridge/nft/batch_bridge_nft_to_evm_and_txs.cdc",
+        [ exampleNFTIdentifier, aliceOwnedIDs, [], [], [], []],
+        alice
+    )
+    Test.expect(bridgeResult, Test.beSucceeded())
 }
 
 access(all)

--- a/cadence/tests/flow_evm_bridge_tests.cdc
+++ b/cadence/tests/flow_evm_bridge_tests.cdc
@@ -762,7 +762,7 @@ fun testBatchBridgeCadenceNativeNFTToEVMSucceeds() {
     // Execute bridge to EVM
     let bridgeResult = executeTransaction(
         "../transactions/bridge/nft/batch_bridge_nft_to_evm.cdc",
-        [ exampleNFTIdentifier, aliceOwnedIDs ],
+        [ exampleNFTIdentifier, aliceOwnedIDs, [], [], [], [] ],
         alice
     )
     Test.expect(bridgeResult, Test.beSucceeded())

--- a/cadence/transactions/bridge/nft/batch_bridge_nft_to_evm.cdc
+++ b/cadence/transactions/bridge/nft/batch_bridge_nft_to_evm.cdc
@@ -13,26 +13,44 @@ import "FlowEVMBridgeConfig"
 import "FlowEVMBridgeUtils"
 
 /// Bridges NFTs (from the same collection) from the signer's collection in Cadence to the signer's COA in FlowEVM
+/// and then performs an arbitrary number of calls afterwards to potentially do things
+/// with the bridged NFTs
 ///
-/// NOTE: This transaction also onboards the NFT to the bridge if necessary which may incur additional fees
-///     than bridging an asset that has already been onboarded.
+/// This transaction assumes that the NFT has already been onboarded to the bridge
 ///
 /// @param nftIdentifier: The Cadence type identifier of the NFT to bridge - e.g. nft.getType().identifier
 /// @param ids: The Cadence NFT.id of the NFTs to bridge to EVM
+/// @params evmContractAddressHexes, calldatas, gasLimits, values: An array of calldata
+///         to be included in transaction calls to Flow EVM from the signer's COA.
+///         The arrays are all expected to be of the same length
 ///
-transaction(nftIdentifier: String, ids: [UInt64]) {
+transaction(
+    nftIdentifier: String,
+    ids: [UInt64],
+    evmContractAddressHexes: [String],
+    calldatas: [String],
+    gasLimits: [UInt64],
+    values: [UFix64]
+) {
 
     let nftType: Type
     let collection: auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Collection}
-    let coa: auth(EVM.Bridge) &EVM.CadenceOwnedAccount
+    let coa: auth(EVM.Bridge, EVM.Call) &EVM.CadenceOwnedAccount
     let requiresOnboarding: Bool
     let scopedProvider: @ScopedFTProviders.ScopedFTProvider
     
     prepare(signer: auth(CopyValue, BorrowValue, IssueStorageCapabilityController, PublishCapability, SaveValue) &Account) {
+        pre {
+            (evmContractAddressHexes.length == calldatas.length)
+            && (calldatas.length == gasLimits.length)
+            && (gasLimits.length == values.length):
+                "Calldata array lengths must all be the same!"
+        }
+
         /* --- Reference the signer's CadenceOwnedAccount --- */
         //
         // Borrow a reference to the signer's COA
-        self.coa = signer.storage.borrow<auth(EVM.Bridge) &EVM.CadenceOwnedAccount>(from: /storage/evm)
+        self.coa = signer.storage.borrow<auth(EVM.Bridge, EVM.Call) &EVM.CadenceOwnedAccount>(from: /storage/evm)
             ?? panic("Could not borrow COA signer's account at path /storage/evm")
         
         /* --- Construct the NFT type --- */
@@ -98,6 +116,7 @@ transaction(nftIdentifier: String, ids: [UInt64]) {
     }
 
     execute {
+
         if self.requiresOnboarding {
             // Onboard the NFT to the bridge
             FlowEVMBridge.onboardByType(
@@ -124,5 +143,22 @@ transaction(nftIdentifier: String, ids: [UInt64]) {
 
         // Destroy the ScopedFTProvider
         destroy self.scopedProvider
+
+        // Perform all the calls
+        for index, evmAddressHex in evmContractAddressHexes { 
+            let evmAddress = EVM.addressFromString(evmAddressHex)
+
+            let valueBalance = EVM.Balance(attoflow: 0)
+            valueBalance.setFLOW(flow: values[index])
+            let callResult = self.coa.call(
+                to: evmAddress,
+                data: calldatas[index].decodeHex(),
+                gasLimit: gasLimits[index],
+                value: valueBalance
+            )
+            assert(
+                callResult.status == EVM.Status.successful,
+                message: "Call failed with address \(evmAddressHex) and calldata \(calldatas[index]) with error \(callResult.errorMessage)")
+        }
     }
 }

--- a/cadence/transactions/bridge/nft/batch_bridge_nft_to_evm_and_txs.cdc
+++ b/cadence/transactions/bridge/nft/batch_bridge_nft_to_evm_and_txs.cdc
@@ -31,7 +31,7 @@ transaction(
     evmContractAddressHexes: [String],
     calldatas: [String],
     gasLimits: [UInt64],
-    values: [UFix64]
+    values: [UInt]
 ) {
 
     let nftType: Type
@@ -149,8 +149,7 @@ transaction(
         for index, evmAddressHex in evmContractAddressHexes { 
             let evmAddress = EVM.addressFromString(evmAddressHex)
 
-            let valueBalance = EVM.Balance(attoflow: 0)
-            valueBalance.setFLOW(flow: values[index])
+            let valueBalance = EVM.Balance(attoflow: values[index])
             let callResult = self.coa.call(
                 to: evmAddress,
                 data: calldatas[index].decodeHex(),

--- a/cadence/transactions/bridge/nft/batch_bridge_nft_to_evm_and_txs.cdc
+++ b/cadence/transactions/bridge/nft/batch_bridge_nft_to_evm_and_txs.cdc
@@ -13,26 +13,45 @@ import "FlowEVMBridgeConfig"
 import "FlowEVMBridgeUtils"
 
 /// Bridges NFTs (from the same collection) from the signer's collection in Cadence to the signer's COA in FlowEVM
+/// and then performs an arbitrary number of calls afterwards to potentially do things
+/// with the bridged NFTs
 ///
 /// NOTE: This transaction also onboards the NFT to the bridge if necessary which may incur additional fees
 ///     than bridging an asset that has already been onboarded.
 ///
 /// @param nftIdentifier: The Cadence type identifier of the NFT to bridge - e.g. nft.getType().identifier
 /// @param ids: The Cadence NFT.id of the NFTs to bridge to EVM
+/// @params evmContractAddressHexes, calldatas, gasLimits, values: Arrays of calldata
+///         to be included in transaction calls to Flow EVM from the signer's COA.
+///         The arrays are all expected to be of the same length
 ///
-transaction(nftIdentifier: String, ids: [UInt64]) {
+transaction(
+    nftIdentifier: String,
+    ids: [UInt64],
+    evmContractAddressHexes: [String],
+    calldatas: [String],
+    gasLimits: [UInt64],
+    values: [UFix64]
+) {
 
     let nftType: Type
     let collection: auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Collection}
-    let coa: auth(EVM.Bridge) &EVM.CadenceOwnedAccount
+    let coa: auth(EVM.Bridge, EVM.Call) &EVM.CadenceOwnedAccount
     let requiresOnboarding: Bool
     let scopedProvider: @ScopedFTProviders.ScopedFTProvider
     
     prepare(signer: auth(CopyValue, BorrowValue, IssueStorageCapabilityController, PublishCapability, SaveValue) &Account) {
+        pre {
+            (evmContractAddressHexes.length == calldatas.length)
+            && (calldatas.length == gasLimits.length)
+            && (gasLimits.length == values.length):
+                "Calldata array lengths must all be the same!"
+        }
+
         /* --- Reference the signer's CadenceOwnedAccount --- */
         //
         // Borrow a reference to the signer's COA
-        self.coa = signer.storage.borrow<auth(EVM.Bridge) &EVM.CadenceOwnedAccount>(from: /storage/evm)
+        self.coa = signer.storage.borrow<auth(EVM.Bridge, EVM.Call) &EVM.CadenceOwnedAccount>(from: /storage/evm)
             ?? panic("Could not borrow COA signer's account at path /storage/evm")
         
         /* --- Construct the NFT type --- */
@@ -98,6 +117,7 @@ transaction(nftIdentifier: String, ids: [UInt64]) {
     }
 
     execute {
+
         if self.requiresOnboarding {
             // Onboard the NFT to the bridge
             FlowEVMBridge.onboardByType(
@@ -124,5 +144,23 @@ transaction(nftIdentifier: String, ids: [UInt64]) {
 
         // Destroy the ScopedFTProvider
         destroy self.scopedProvider
+
+        // Perform all the calls
+        for index, evmAddressHex in evmContractAddressHexes { 
+            let evmAddress = EVM.addressFromString(evmAddressHex)
+
+            let valueBalance = EVM.Balance(attoflow: 0)
+            valueBalance.setFLOW(flow: values[index])
+            let callResult = self.coa.call(
+                to: evmAddress,
+                data: calldatas[index].decodeHex(),
+                gasLimit: gasLimits[index],
+                value: valueBalance
+            )
+            assert(
+                callResult.status == EVM.Status.successful,
+                message: "Call failed with address \(evmAddressHex) and calldata \(calldatas[index]) with error \(callResult.errorMessage)"
+            )
+        }
     }
 }

--- a/cadence/transactions/bridge/tokens/bridge_tokens_to_evm_and_txs.cdc
+++ b/cadence/transactions/bridge/tokens/bridge_tokens_to_evm_and_txs.cdc
@@ -31,7 +31,7 @@ transaction(
     evmContractAddressHexes: [String],
     calldatas: [String],
     gasLimits: [UInt64],
-    values: [UFix64]
+    values: [UInt]
 ) {
 
     let sentVault: @{FungibleToken.Vault}
@@ -140,8 +140,7 @@ transaction(
         for index, evmAddressHex in evmContractAddressHexes { 
             let evmAddress = EVM.addressFromString(evmAddressHex)
 
-            let valueBalance = EVM.Balance(attoflow: 0)
-            valueBalance.setFLOW(flow: values[index])
+            let valueBalance = EVM.Balance(attoflow: values[index])
             let callResult = self.coa.call(
                 to: evmAddress,
                 data: calldatas[index].decodeHex(),

--- a/cadence/transactions/bridge/tokens/bridge_tokens_to_evm_and_txs.cdc
+++ b/cadence/transactions/bridge/tokens/bridge_tokens_to_evm_and_txs.cdc
@@ -1,0 +1,157 @@
+import "FungibleToken"
+import "ViewResolver"
+import "FungibleTokenMetadataViews"
+import "FlowToken"
+
+import "ScopedFTProviders"
+
+import "EVM"
+
+import "FlowEVMBridge"
+import "FlowEVMBridgeConfig"
+import "FlowEVMBridgeUtils"
+
+/// Bridges a Vault from the signer's storage to the signer's COA in EVM.Account
+/// and then executes an arbitrary number of EVM transactions.
+///
+/// NOTE: This transaction also onboards the Vault to the bridge if necessary which may incur additional fees
+///     than bridging an asset that has already been onboarded.
+///
+/// @param vaultIdentifier: The Cadence type identifier of the FungibleToken Vault to bridge
+///     - e.g. vault.getType().identifier
+/// @param amount: The amount of tokens to bridge from EVM
+/// @params evmContractAddressHexes, calldatas, gasLimits, values: Arrays of calldata
+///         to be included in transaction calls to Flow EVM from the signer's COA.
+///         The arrays are all expected to be of the same length
+///
+///
+transaction(
+    vaultIdentifier: String,
+    amount: UFix64,
+    evmContractAddressHexes: [String],
+    calldatas: [String],
+    gasLimits: [UInt64],
+    values: [UFix64]
+) {
+
+    let sentVault: @{FungibleToken.Vault}
+    let coa: auth(EVM.Bridge, EVM.Call) &EVM.CadenceOwnedAccount
+    let requiresOnboarding: Bool
+    let scopedProvider: @ScopedFTProviders.ScopedFTProvider
+
+    prepare(signer: auth(CopyValue, BorrowValue, IssueStorageCapabilityController, PublishCapability, SaveValue) &Account) {
+        pre {
+            (evmContractAddressHexes.length == calldatas.length)
+            && (calldatas.length == gasLimits.length)
+            && (gasLimits.length == values.length):
+                "Calldata array lengths must all be the same!"
+        }
+
+        /* --- Reference the signer's CadenceOwnedAccount --- */
+        //
+        // Borrow a reference to the signer's COA
+        self.coa = signer.storage.borrow<auth(EVM.Bridge, EVM.Call) &EVM.CadenceOwnedAccount>(from: /storage/evm)
+            ?? panic("Could not borrow COA signer's account at path /storage/evm")
+
+        /* --- Construct the Vault type --- */
+        //
+        // Construct the Vault type from the provided identifier
+        let vaultType = CompositeType(vaultIdentifier)
+            ?? panic("Could not construct Vault type from identifier: ".concat(vaultIdentifier))
+        // Parse the Vault identifier into its components
+        let tokenContractAddress = FlowEVMBridgeUtils.getContractAddress(fromType: vaultType)
+            ?? panic("Could not get contract address from identifier: ".concat(vaultIdentifier))
+        let tokenContractName = FlowEVMBridgeUtils.getContractName(fromType: vaultType)
+            ?? panic("Could not get contract name from identifier: ".concat(vaultIdentifier))
+
+        /* --- Retrieve the funds --- */
+        //
+        // Borrow a reference to the FungibleToken Vault
+        let viewResolver = getAccount(tokenContractAddress).contracts.borrow<&{ViewResolver}>(name: tokenContractName)
+            ?? panic("Could not borrow ViewResolver from FungibleToken contract with name"
+                .concat(tokenContractName).concat(" and address ")
+                .concat(tokenContractAddress.toString()))
+        let vaultData = viewResolver.resolveContractView(
+                resourceType: vaultType,
+                viewType: Type<FungibleTokenMetadataViews.FTVaultData>()
+            ) as! FungibleTokenMetadataViews.FTVaultData?
+            ?? panic("Could not resolve FTVaultData view for Vault type ".concat(vaultType.identifier))
+        let vault = signer.storage.borrow<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(
+                from: vaultData.storagePath
+            ) ?? panic("Could not borrow FungibleToken Vault from storage path ".concat(vaultData.storagePath.toString()))
+
+        // Withdraw the requested balance & set a cap on the withdrawable bridge fee
+        self.sentVault <- vault.withdraw(amount: amount)
+        var approxFee = FlowEVMBridgeUtils.calculateBridgeFee(
+                bytes: 400_000 // 400 kB as upper bound on movable storage used in a single transaction
+            )
+        // Determine if the Vault requires onboarding - this impacts the fee required
+        self.requiresOnboarding = FlowEVMBridge.typeRequiresOnboarding(self.sentVault.getType())
+            ?? panic("Bridge does not support the requested asset type ".concat(vaultIdentifier))
+        if self.requiresOnboarding {
+            approxFee = approxFee + FlowEVMBridgeConfig.onboardFee
+        }
+
+        /* --- Configure a ScopedFTProvider --- */
+        //
+        // Issue and store bridge-dedicated Provider Capability in storage if necessary
+        if signer.storage.type(at: FlowEVMBridgeConfig.providerCapabilityStoragePath) == nil {
+            let providerCap = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>(
+                /storage/flowTokenVault
+            )
+            signer.storage.save(providerCap, to: FlowEVMBridgeConfig.providerCapabilityStoragePath)
+        }
+        // Copy the stored Provider capability and create a ScopedFTProvider
+        let providerCapCopy = signer.storage.copy<Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>>(
+                from: FlowEVMBridgeConfig.providerCapabilityStoragePath
+            ) ?? panic("Invalid FungibleToken Provider Capability found in storage at path "
+                .concat(FlowEVMBridgeConfig.providerCapabilityStoragePath.toString()))
+        let providerFilter = ScopedFTProviders.AllowanceFilter(approxFee)
+        self.scopedProvider <- ScopedFTProviders.createScopedFTProvider(
+                provider: providerCapCopy,
+                filters: [ providerFilter ],
+                expiration: getCurrentBlock().timestamp + 1.0
+            )
+    }
+
+    pre {
+        self.sentVault.getType().identifier == vaultIdentifier:
+            "Attempting to send invalid vault type - requested: ".concat(vaultIdentifier)
+            .concat(", sending: ").concat(self.sentVault.getType().identifier)
+    }
+
+    execute {
+        if self.requiresOnboarding {
+            // Onboard the Vault to the bridge
+            FlowEVMBridge.onboardByType(
+                self.sentVault.getType(),
+                feeProvider: &self.scopedProvider as auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+            )
+        }
+        // Execute the bridge
+        self.coa.depositTokens(
+            vault: <-self.sentVault,
+            feeProvider: &self.scopedProvider as auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
+        )
+        // Destroy the ScopedFTProvider
+        destroy self.scopedProvider
+
+        // Perform all the calls
+        for index, evmAddressHex in evmContractAddressHexes { 
+            let evmAddress = EVM.addressFromString(evmAddressHex)
+
+            let valueBalance = EVM.Balance(attoflow: 0)
+            valueBalance.setFLOW(flow: values[index])
+            let callResult = self.coa.call(
+                to: evmAddress,
+                data: calldatas[index].decodeHex(),
+                gasLimit: gasLimits[index],
+                value: valueBalance
+            )
+            assert(
+                callResult.status == EVM.Status.successful,
+                message: "Call failed with address \(evmAddressHex) and calldata \(calldatas[index]) with error \(callResult.errorMessage)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Works towards https://github.com/onflow/fcl-js/issues/2340 and https://github.com/onflow/fcl-js/issues/2339

## Description

Updates the batch bridge to EVM transaction to all take an arbitrary amount of calldata so that the caller can do any EVM calls in the same transaction.

I wanted to just update the existing transaction so that we don't have to copy code and to make it a little easier to illustrate to developers the ability to do many things in one atomic transaction.

______

For contributor use:

- [x] Targeted PR against `flip-318` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [x] Re-reviewed `Files changed` in the Github PR explorer