### PR TITLE
Fix pause by type on custom associations

### DIFF
--- a/cadence/contracts/bridge/FlowEVMBridgeCustomAssociations.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeCustomAssociations.cdc
@@ -181,7 +181,7 @@ access(all) contract FlowEVMBridgeCustomAssociations {
     access(account) fun pauseCustomConfig(forType: Type) {
         let config = self.borrowNFTCustomConfig(forType: forType)
             ?? panic("No CustomConfig found for type \(forType.identifier) - cannot pause config that does not exist")
-        if config.isPaused() {
+        if !config.isPaused() {
             config.setPauseStatus(true)
         }
     }

--- a/cadence/tests/flow_evm_bridge_cadence_native_nft_tests.cdc
+++ b/cadence/tests/flow_evm_bridge_cadence_native_nft_tests.cdc
@@ -117,6 +117,25 @@ fun testRegisterAgainFails() {
 }
 
 access(all)
+fun testPauseByTypeSucceeds() {
+    Test.reset(to: snapshot)
+
+    registerCrossVMNFT(
+        signer: exampleCadenceNativeNFTAccount,
+        nftTypeIdentifier: exampleCadenceNativeNFTIdentifier,
+        fulfillmentMinterPath: nil,
+        beFailed: false
+    )
+
+    var isPaused = isTypePaused(typeIdentifier: exampleCadenceNativeNFTIdentifier)!
+    Test.assertEqual(false, isPaused)
+    updateTypePauseStatus(signer: bridgeAccount, typeIdentifier: exampleCadenceNativeNFTIdentifier, pause: true)
+
+    isPaused = isTypePaused(typeIdentifier: exampleCadenceNativeNFTIdentifier)!
+    Test.assertEqual(true, isPaused)
+}
+
+access(all)
 fun testOnboardCadenceNativeNFTByIdentifierSucceeds() {
     Test.reset(to: snapshot)
 

--- a/cadence/tests/flow_evm_bridge_evm_native_nft_tests.cdc
+++ b/cadence/tests/flow_evm_bridge_evm_native_nft_tests.cdc
@@ -117,6 +117,25 @@ fun testRegisterAgainFails() {
 }
 
 access(all)
+fun testPauseByTypeSucceeds() {
+    Test.reset(to: snapshot)
+
+    registerCrossVMNFT(
+        signer: exampleEVMNativeNFTAccount,
+        nftTypeIdentifier: exampleEVMNativeNFTIdentifier,
+        fulfillmentMinterPath: ExampleEVMNativeNFT.FulfillmentMinterStoragePath,
+        beFailed: false
+    )
+
+    var isPaused = isTypePaused(typeIdentifier: exampleEVMNativeNFTIdentifier)!
+    Test.assertEqual(false, isPaused)
+    updateTypePauseStatus(signer: bridgeAccount, typeIdentifier: exampleEVMNativeNFTIdentifier, pause: true)
+
+    isPaused = isTypePaused(typeIdentifier: exampleEVMNativeNFTIdentifier)!
+    Test.assertEqual(true, isPaused)
+}
+
+access(all)
 fun testRegisterEVMNativeNFTWithoutMinterFails() {
     Test.reset(to: snapshot)
 

--- a/cadence/tests/flow_evm_bridge_tests.cdc
+++ b/cadence/tests/flow_evm_bridge_tests.cdc
@@ -945,18 +945,9 @@ fun testBridgeEVMNativeNFTFromEVMSucceeds() {
 access(all)
 fun testPauseByTypeSucceeds() {
     // Pause the bridge
-    let pauseResult = executeTransaction(
-        "../transactions/bridge/admin/pause/update_type_pause_status.cdc",
-        [exampleNFTIdentifier, true],
-        bridgeAccount
-    )
-    Test.expect(pauseResult, Test.beSucceeded())
-    var isPausedResult = executeScript(
-        "../scripts/bridge/is_type_paused.cdc",
-        [exampleNFTIdentifier]
-    )
-    Test.expect(isPausedResult, Test.beSucceeded())
-    Test.assertEqual(true, isPausedResult.returnValue as! Bool? ?? panic("Problem getting pause status"))
+    updateTypePauseStatus(signer: bridgeAccount, typeIdentifier: exampleNFTIdentifier, pause: true)
+    var isPaused = isTypePaused(typeIdentifier: exampleNFTIdentifier)!
+    Test.assertEqual(true, isPaused)
 
     var aliceOwnedIDs = getIDs(ownerAddr: alice.address, storagePathIdentifier: "cadenceExampleNFTCollection")
     Test.assertEqual(1, aliceOwnedIDs.length)
@@ -973,19 +964,10 @@ fun testPauseByTypeSucceeds() {
     )
 
     // Unpause bridging
-    let unpauseResult = executeTransaction(
-        "../transactions/bridge/admin/pause/update_type_pause_status.cdc",
-        [exampleNFTIdentifier, false],
-        bridgeAccount
-    )
-    Test.expect(unpauseResult, Test.beSucceeded())
+    updateTypePauseStatus(signer: bridgeAccount, typeIdentifier: exampleNFTIdentifier, pause: false)
 
-    isPausedResult = executeScript(
-        "../scripts/bridge/is_type_paused.cdc",
-        [exampleNFTIdentifier]
-    )
-    Test.expect(isPausedResult, Test.beSucceeded())
-    Test.assertEqual(false, isPausedResult.returnValue as! Bool? ?? panic("Problem getting pause status"))
+    isPaused = isTypePaused(typeIdentifier: exampleNFTIdentifier)!
+    Test.assertEqual(false, isPaused)
 }
 
 access(all)

--- a/cadence/tests/test_helpers.cdc
+++ b/cadence/tests/test_helpers.cdc
@@ -263,6 +263,16 @@ fun getTypeAssociated(with evmAddress: String): String {
 }
 
 access(all)
+fun isTypePaused(typeIdentifier: String): Bool? {
+    var isPausedResult = _executeScript(
+        "../scripts/bridge/is_type_paused.cdc",
+        [typeIdentifier]
+    )
+    Test.expect(isPausedResult, Test.beSucceeded())
+    return isPausedResult.returnValue as! Bool? ?? panic("Problem getting pause status for type \(typeIdentifier)")
+}
+
+access(all)
 fun getAssociatedEVMAddressHex(with typeIdentifier: String): String {
     var associatedEVMAddressResult = _executeScript(
         "../scripts/bridge/get_associated_evm_address.cdc",
@@ -562,6 +572,16 @@ fun updateBridgePauseStatus(signer: Test.TestAccount, pause: Bool) {
     let pauseResult = _executeTransaction(
         "../transactions/bridge/admin/pause/update_bridge_pause_status.cdc",
         [pause],
+        signer
+    )
+    Test.expect(pauseResult, Test.beSucceeded())
+}
+
+access(all)
+fun updateTypePauseStatus(signer: Test.TestAccount, typeIdentifier: String, pause: Bool) {
+    let pauseResult = _executeTransaction(
+        "../transactions/bridge/admin/pause/update_type_pause_status.cdc",
+        [typeIdentifier, pause],
         signer
     )
     Test.expect(pauseResult, Test.beSucceeded())


### PR DESCRIPTION
## Description

- Fixes a bug in `FlowEVMBridgeCustomAssociations.pauseCustomConfig` wherein the config was not properly paused from unpaused status
- Adds test coverage ensuring the pause status is actually updated as intended

______

For contributor use:

- [ ] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 