### PR TITLE
Config followup to #191

### DIFF
--- a/flow.json
+++ b/flow.json
@@ -98,14 +98,18 @@
 			"source": "./cadence/contracts/bridge/FlowEVMBridgeCustomAssociationTypes.cdc",
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
-				"testing": "0000000000000007"
+				"mainnet": "1e4aa0b87d10b141",
+				"testing": "0000000000000007",
+				"testnet": "dfc20aee650fcbdf"
 			}
 		},
 		"FlowEVMBridgeCustomAssociations": {
 			"source": "./cadence/contracts/bridge/FlowEVMBridgeCustomAssociations.cdc",
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
-				"testing": "0000000000000007"
+				"mainnet": "1e4aa0b87d10b141",
+				"testing": "0000000000000007",
+				"testnet": "dfc20aee650fcbdf"
 			}
 		},
 		"FlowEVMBridgeHandlerInterfaces": {
@@ -462,7 +466,9 @@
 				"IEVMBridgeTokenMinter",
 				"IFlowEVMNFTBridge",
 				"IFlowEVMTokenBridge",
-				"FlowEVMBridge"
+				"FlowEVMBridge",
+				"FlowEVMBridgeCustomAssociationTypes",
+				"FlowEVMBridgeCustomAssociations"
 			]
 		},
 		"testnet": {
@@ -489,7 +495,9 @@
 				"IEVMBridgeTokenMinter",
 				"IFlowEVMNFTBridge",
 				"IFlowEVMTokenBridge",
-				"FlowEVMBridge"
+				"FlowEVMBridge",
+				"FlowEVMBridgeCustomAssociationTypes",
+				"FlowEVMBridgeCustomAssociations"
 			]
 		}
 	}


### PR DESCRIPTION
## Description

Updates flow.json with Testnet & Mainnet  aliases for FlowEVMBridgeCustomAssociationTypes & FlowEVMBridgeCustomAssociations contracts

______

For contributor use:

- [x] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 