### PR TITLE
Fix EVM-to-Cadence bridging precision loss

### DIFF
--- a/cadence/contracts/bridge/FlowEVMBridgeAccessor.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeAccessor.cdc
@@ -6,6 +6,7 @@ import "EVM"
 
 import "FlowEVMBridgeConfig"
 import "FlowEVMBridge"
+import "FlowEVMBridgeUtils"
 
 /// This contract defines a mechanism for routing bridge requests from the EVM contract to the Flow-EVM bridge contract
 ///
@@ -119,6 +120,13 @@ contract FlowEVMBridgeAccessor {
             amount: UInt256,
             feeProvider: auth(FungibleToken.Withdraw) &{FungibleToken.Provider}
         ): @{FungibleToken.Vault} {
+            // Resolve the EVM address associated with the token type
+            let associatedEVMAddress = FlowEVMBridge.getAssociatedEVMAddress(with: type)
+                ?? panic("No EVM address associated with type")
+            // Round the requested ERC20 amount down to the maximum precision representable by UFix64 to ensure the
+            // amount escrowed on the EVM side matches exactly what will be minted or unlocked on the Cadence side,
+            // preventing sub-UFix64-precision "dust" from being permanently locked in escrow.
+            let roundedAmount = FlowEVMBridgeUtils.castERC20AmountToCadencePrecision(amount, erc20Address: associatedEVMAddress)
             // Define a callback function, enabling the bridge to act on the ephemeral COA reference in scope
             var executed = false
             fun callback(): EVM.Result {
@@ -130,11 +138,10 @@ contract FlowEVMBridgeAccessor {
                 }
                 executed = true
                 return caller.call(
-                    to: FlowEVMBridge.getAssociatedEVMAddress(with: type)
-                        ?? panic("No EVM address associated with type"),
+                    to: associatedEVMAddress,
                     data: EVM.encodeABIWithSignature(
                         "transfer(address,uint256)",
-                        [FlowEVMBridge.getBridgeCOAEVMAddress(), amount]
+                        [FlowEVMBridge.getBridgeCOAEVMAddress(), roundedAmount]
                     ),
                     gasLimit: FlowEVMBridgeConfig.gasLimit,
                     value: EVM.Balance(attoflow: 0)
@@ -144,7 +151,7 @@ contract FlowEVMBridgeAccessor {
             return <- FlowEVMBridge.bridgeTokensFromEVM(
                 owner: caller.address(),
                 type: type,
-                amount: amount,
+                amount: roundedAmount,
                 feeProvider: feeProvider,
                 protectedTransferCall: callback
             )

--- a/cadence/contracts/bridge/FlowEVMBridgeUtils.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeUtils.cdc
@@ -820,6 +820,23 @@ contract FlowEVMBridgeUtils {
         return self.ufix64ToUInt256(value: amount, decimals: self.getTokenDecimals(evmContractAddress: erc20Address))
     }
 
+    /// Converts the given ERC20 amount to the corresponding ERC20 amount after rounding down to the maximum precision
+    /// representable by UFix64 (8 decimal places). This ensures that the amount escrowed on the EVM side matches
+    /// exactly the amount that will be minted or unlocked on the Cadence side, preventing sub-UFix64-precision
+    /// "dust" from being permanently locked in escrow without a corresponding Cadence representation.
+    ///
+    /// @param amount: The UInt256 ERC20 amount to cast to Cadence precision
+    /// @param erc20Address: The EVM contract address of the ERC20 token
+    ///
+    /// @return The ERC20 UInt256 amount corresponding to the truncated Cadence UFix64 amount
+    ///
+    access(all)
+    fun castERC20AmountToCadencePrecision(_ amount: UInt256, erc20Address: EVM.EVMAddress): UInt256 {
+        let decimals = self.getTokenDecimals(evmContractAddress: erc20Address)
+        let ufixAmount = self.uint256ToUFix64(value: amount, decimals: decimals)
+        return self.ufix64ToUInt256(value: ufixAmount, decimals: decimals)
+    }
+
     /// Gets the declared Cadence contract address declared by an EVM contract in conformance to the ICrossVM.sol
     /// contract interface. Reverts if the EVM call is unsuccessful.
     /// NOTE: Just because an EVM contract declares an association does not mean it it is valid!

--- a/cadence/tests/flow_evm_bridge_tests.cdc
+++ b/cadence/tests/flow_evm_bridge_tests.cdc
@@ -1234,3 +1234,68 @@ fun testBridgeEVMNativeTokenToEVMSucceeds() {
     bridgeCOAEscrowBalance = balanceOf(evmAddressHex: bridgeCOAAddressHex, erc20AddressHex: erc20AddressHex)
     Test.assertEqual(UInt256(0), bridgeCOAEscrowBalance)
 }
+
+// Verifies that when bridging an EVM-native ERC20 whose amount has sub-UFix64-precision "dust", only the
+// rounded-down amount is escrowed and minted on the Cadence side, with the dust left in the caller's EVM wallet.
+access(all)
+fun testBridgeEVMNativeTokenFromEVMWithDustSucceeds() {
+    let derivedERC20ContractName = deriveBridgedTokenContractName(evmAddressHex: erc20AddressHex)
+    let bridgedVaultPathIdentifier = derivedERC20ContractName.concat("Vault")
+    let aliceCOAAddressHex = getCOAAddressHex(atFlowAddress: alice.address)
+    let bridgeCOAAddressHex = getCOAAddressHex(atFlowAddress: bridgeAccount.address)
+
+    // Confirm Alice's EVM COA has erc20MintAmount from the prior test
+    var evmBalance = balanceOf(evmAddressHex: aliceCOAAddressHex, erc20AddressHex: erc20AddressHex)
+    Test.assertEqual(erc20MintAmount, evmBalance)
+
+    // Mint 1 extra wei to Alice's COA to create a sub-UFix64-precision "dust" amount.
+    // erc20MintAmount (100e18) is exactly representable in UFix64, but adding 1 wei pushes it
+    // beyond the 8-decimal precision of UFix64, creating unrepresentable dust.
+    let dustAmount: UInt256 = 1
+    let mintResult = executeTransaction(
+        "../transactions/example-assets/evm-assets/mint_erc20.cdc",
+        [aliceCOAAddressHex, dustAmount, erc20AddressHex, UInt64(200_000)],
+        exampleERCAccount
+    )
+    Test.expect(mintResult, Test.beSucceeded())
+
+    let dustyEvmBalance = erc20MintAmount + dustAmount
+    evmBalance = balanceOf(evmAddressHex: aliceCOAAddressHex, erc20AddressHex: erc20AddressHex)
+    Test.assertEqual(dustyEvmBalance, evmBalance)
+
+    // Confirm the dusty amount rounds down to erc20MintAmount in UFix64 precision
+    let decimals = getTokenDecimals(erc20AddressHex: erc20AddressHex)
+    let roundedDownAmount = ufix64ToUInt256(uint256ToUFix64(dustyEvmBalance, decimals: decimals), decimals: decimals)
+    Test.assertEqual(erc20MintAmount, roundedDownAmount)
+
+    // Confirm Alice's Cadence vault balance before bridging
+    var cadenceBalance = getBalance(ownerAddr: alice.address, storagePathIdentifier: bridgedVaultPathIdentifier)
+        ?? panic("Bridged token Vault was not found in Alice's account")
+    Test.assertEqual(0.0, cadenceBalance)
+
+    // Bridge from EVM with the dusty amount - the bridge should only transfer the rounded-down amount
+    bridgeTokensFromEVM(
+        signer: alice,
+        vaultIdentifier: buildTypeIdentifier(
+            address: bridgeAccount.address,
+            contractName: derivedERC20ContractName,
+            resourceName: "Vault"
+        ),
+        amount: dustyEvmBalance,
+        beFailed: false
+    )
+
+    // Confirm Alice's EVM COA retains only the dust (1 wei) - not charged for unrepresentable precision
+    evmBalance = balanceOf(evmAddressHex: aliceCOAAddressHex, erc20AddressHex: erc20AddressHex)
+    Test.assertEqual(dustAmount, evmBalance)
+
+    // Confirm Alice's Cadence vault received the rounded-down amount (100.0, no dust)
+    cadenceBalance = getBalance(ownerAddr: alice.address, storagePathIdentifier: bridgedVaultPathIdentifier)
+        ?? panic("Bridged token Vault was not found in Alice's account after bridging")
+    let expectedCadenceBalance = uint256ToUFix64(erc20MintAmount, decimals: decimals)
+    Test.assertEqual(expectedCadenceBalance, cadenceBalance)
+
+    // Confirm the bridge COA escrowed only the rounded amount, not the full dusty amount
+    let bridgeCOAEscrowBalance = balanceOf(evmAddressHex: bridgeCOAAddressHex, erc20AddressHex: erc20AddressHex)
+    Test.assertEqual(erc20MintAmount, bridgeCOAEscrowBalance)
+}


### PR DESCRIPTION
Closes #193

When bridging ERC20 tokens from EVM to Cadence, amounts with sub-UFix64 precision (beyond 8 decimal places) were previously escrowed in full while only the truncated UFix64 amount was minted/unlocked on Cadence, permanently locking the "dust" in escrow. The fix rounds the requested ERC20 amount down to the maximum UFix64-representable amount before the EVM transfer, so the user retains any unrepresentable dust in their EVM wallet.

- Add `castERC20AmountToCadencePrecision` to FlowEVMBridgeUtils: rounds a UInt256 ERC20 amount down to the corresponding amount after UFix64 truncation using a single `getTokenDecimals` call
- Update `FlowEVMBridgeAccessor.withdrawTokens` to compute the rounded amount before constructing the protected transfer callback, ensuring the ERC20 transfer, escrow check, and bridge call all use the same UFix64-representable amount
- Add `testBridgeEVMNativeTokenFromEVMWithDustSucceeds` integration test verifying that 1 wei of dust is retained in the caller's EVM wallet rather than locked in bridge escrow

For contributor use:

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 