### PR TITLE
Clarify NFT bridge fee model: fees apply only to storage-consuming operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ standard contract interfaces.
 
 Like all operations on Flow, there are native fees associated with both computation and storage. To prevent spam and
 sustain the bridge account's storage consumption, fees are charged for both onboarding assets and bridging assets. In
-the case where storage consumption is expected, fees are charges based on the storage consumed at the current network
-rates. In all cases, there is a flat-rate fee in addition to any storage fees.
+the case where storage consumption is expected, fees are charged based on the storage consumed at the current network
+rates. Fees are only charged when the bridge operation causes the bridge account to store an asset long-term (e.g.
+escrowing a Cadence NFT). Operations that burn assets or release them from existing escrow do not incur a bridge fee,
+as they do not add to the bridge account's storage.
 
 ### Onboarding
 

--- a/cadence/contracts/bridge/FlowEVMBridge.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridge.cdc
@@ -931,6 +931,8 @@ contract FlowEVMBridge : IFlowEVMNFTBridge, IFlowEVMTokenBridge {
             erc721Address: bridgedAssociation.toString()
         )
         Burner.burn(<-bridgedToken)
+        // No bridge fee is charged here. The bridge burns the legacy Cadence NFT and releases the ERC721 from
+        // EVM-side escrow — no new assets are added to bridge storage, so no storage cost is incurred.
         // Transfer the ERC721 from escrow to the named recipient
         FlowEVMBridgeUtils.mustSafeTransferERC721(erc721Address: bridgedAssociation, to: to, id: evmID)
     }
@@ -1085,6 +1087,9 @@ contract FlowEVMBridge : IFlowEVMNFTBridge, IFlowEVMTokenBridge {
                 protectedTransferCall: protectedTransferCall
             )
         }
+        // No bridge fee is charged here. The bridge is releasing a Cadence-native NFT from existing escrow — the
+        // storage cost was already accounted for when the NFT was escrowed on the ToEVM path. Unlocking reduces
+        // bridge storage rather than increasing it, so no new fee is warranted.
         // Cadence-native NFTs must be in escrow, so unlock & return
         return <-FlowEVMBridgeNFTEscrow.unlockNFT(
             type: type,
@@ -1130,6 +1135,9 @@ contract FlowEVMBridge : IFlowEVMNFTBridge, IFlowEVMTokenBridge {
 
         FlowEVMBridgeUtils.mustEscrowERC721(owner: owner, id: id, erc721Address: erc721Address, protectedTransferCall: protectedTransferCall)
 
+        // No bridge fee is charged here. EVM-native NFTs are fulfilled either by unlocking from existing Cadence
+        // escrow (reducing bridge storage) or by minting via the project-provided NFTFulfillmentMinter (no bridge
+        // storage involved). In neither case does the bridge account incur a new storage cost.
         if FlowEVMBridgeNFTEscrow.isLocked(type: type, id: UInt64(id)) {
             // Unlock the NFT from escrow
             return <-FlowEVMBridgeNFTEscrow.unlockNFT(type: _type, id: UInt64(id))
@@ -1181,6 +1189,10 @@ contract FlowEVMBridge : IFlowEVMNFTBridge, IFlowEVMTokenBridge {
             )
             Burner.burn(<-bridgedToken)
         }
+        // No bridge fee is charged here. The legacy bridge-defined NFT (if present in escrow) is burned, and the
+        // custom type NFT is either unlocked from existing escrow or minted via the project's NFTFulfillmentMinter.
+        // In all cases the bridge is releasing or burning assets rather than storing new ones, so no storage cost
+        // is incurred and no fee is warranted.
         // Either unlock if locked or fulfill via configured NFTFulfillmentMinter
         if FlowEVMBridgeNFTEscrow.isLocked(type: updatedTypeAssoc, id: UInt64(id)) {
             return <- FlowEVMBridgeNFTEscrow.unlockNFT(type: updatedTypeAssoc, id: UInt64(id))


### PR DESCRIPTION
## Summary

Closes #200.

- Updates README to remove the inaccurate claim that a flat-rate fee is charged in all cases. Fees are only charged when a bridge operation causes the bridge account to store an asset long-term.
- Adds inline comments to the four NFT handlers that accept `feeProvider` but intentionally do not charge a fee, explaining that each operation burns or releases from existing escrow and therefore incurs no new storage cost.

## Affected handlers

| Handler | Reason no fee is charged |
|---------|--------------------------|
| `handleUpdatedBridgedNFTToEVM` | Burns the legacy Cadence NFT and releases ERC721 from EVM-side escrow — no new bridge storage |
| `handleCadenceNativeCrossVMNFTFromEVM` | Releases a Cadence-native NFT from existing escrow — storage cost was paid on the ToEVM path |
| `handleEVMNativeCrossVMNFTFromEVM` | Unlocks from existing escrow or mints via project's `NFTFulfillmentMinter` — no bridge storage involved |
| `handleUpdatedBridgedNFTFromEVM` | Burns legacy bridged NFT and unlocks/fulfills custom type — releasing/burning, not storing |

## Test plan

- [ ] Existing test suite passes without modification (`make cdc-test`)
- [ ] No behavioral changes — code in all four handlers is unchanged