### PR TITLE
Fix pauseType bypass via bridge-defined type in ToEVM direction

### DIFF
--- a/cadence/contracts/bridge/FlowEVMBridge.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridge.cdc
@@ -920,6 +920,12 @@ contract FlowEVMBridge : IFlowEVMNFTBridge, IFlowEVMTokenBridge {
             ?? panic("Could not find a custom cross-VM association for NFT \(token.getType().identifier) #\(token.id). "
                 .concat("The handleUpdatedBridgedNFTToEVM route is intended for bridged Cadence NFTs associated with ")
                 .concat(" ERC721 contracts that have registered as a custom cross-VM NFT collection."))
+
+        // Ensure the updated/custom type is not paused - the top-level pause check only covers the
+        // caller-supplied bridge-defined type, so we must re-check here after resolving the migration target
+        assert(FlowEVMBridgeConfig.isTypePaused(updatedCadenceAssociation) == false,
+            message: "Bridging is currently paused for type \(updatedCadenceAssociation.identifier)")
+
         let tokenRef = (&token as &{NonFungibleToken.NFT}) as! &{CrossVMNFT.EVMNFT}
         let evmID = tokenRef.evmID
         let bridgedToken <- token as! @{CrossVMNFT.EVMNFT}

--- a/cadence/tests/flow_evm_bridge_update_evm_nft_from_bridged_tests.cdc
+++ b/cadence/tests/flow_evm_bridge_update_evm_nft_from_bridged_tests.cdc
@@ -475,6 +475,72 @@ fun testMigrateBridgedNFTAfterUpdatingSucceeds() {
     Test.assertEqual(UInt64(erc721ID), ids[0])
 }
 
+// Verifies that pausing the custom type blocks ToEVM bridging via the custom type identifier (bridge-defined NFT path).
+access(all)
+fun testPauseCustomTypeBlocksBridgeToEVMViaBridgeDefinedType() {
+    Test.reset(to: snapshot)
+
+    let user = Test.createAccount()
+    setupAccount(user, flowAmount: 10.0, coaAmount: 1.0)
+    let userCOAHex = getCOAAddressHex(atFlowAddress: user.address)
+
+    onboardByEVMAddress(signer: user, evmAddressHex: proxyAddressHex, beFailed: false)
+    bridgedNFTIdentifier = getTypeAssociated(with: proxyAddressHex)
+
+    // Mint ERC721 and bridge it from EVM as bridge-defined NFT (before custom association is registered)
+    let mintCalldata = EVM.encodeABIWithSignature("safeMint(address,uint256)", [EVM.addressFromString(userCOAHex), erc721ID])
+    let mintRes = executeTransaction(
+        "../transactions/evm/call.cdc",
+        [proxyAddressHex, String.encodeHex(mintCalldata), UInt64(15_000_000), UInt(0)],
+        erc721Account
+    )
+    Test.expect(mintRes, Test.beSucceeded())
+
+    bridgeNFTFromEVM(
+        signer: user,
+        nftIdentifier: bridgedNFTIdentifier,
+        erc721ID: erc721ID,
+        bridgeAccountAddr: bridgeAccount.address,
+        beFailed: false
+    )
+
+    let derivedERC721ContractName = deriveBridgedNFTContractName(evmAddressHex: proxyAddressHex)
+    let bridgedCollectionPathIdentifier = derivedERC721ContractName.concat("Collection")
+    let ids = getIDs(ownerAddr: user.address, storagePathIdentifier: bridgedCollectionPathIdentifier)
+    Test.assertEqual(1, ids.length)
+    let bridgedNFTID = ids[0]
+
+    let err = Test.deployContract(
+        name: "ExampleEVMNativeNFTGivenEVMAddress",
+        path: "../contracts/example-assets/cross-vm-nfts/ExampleEVMNativeNFTGivenEVMAddress.cdc",
+        arguments: [proxyAddressHex]
+    )
+    Test.expect(err, Test.beNil())
+    customNFTIdentifier = Type<@ExampleEVMNativeNFTGivenEVMAddress.NFT>().identifier
+    upgradeERC721()
+
+    registerCrossVMNFT(
+        signer: erc721Account,
+        nftTypeIdentifier: customNFTIdentifier,
+        fulfillmentMinterPath: ExampleEVMNativeNFTGivenEVMAddress.FulfillmentMinterStoragePath,
+        beFailed: false
+    )
+
+    // Pause only the custom type
+    updateTypePauseStatus(signer: bridgeAccount, typeIdentifier: customNFTIdentifier, pause: true)
+    Test.assertEqual(true, isTypePaused(typeIdentifier: customNFTIdentifier)!)
+
+    // Bridging the bridge-defined NFT to EVM should be blocked now that the fix is in place.
+    // Before the fix, this would succeed and release the ERC721 to the user despite the custom type being paused.
+    bridgeNFTToEVM(
+        signer: user,
+        nftIdentifier: bridgedNFTIdentifier,
+        nftID: bridgedNFTID,
+        bridgeAccountAddr: bridgeAccount.address,
+        beFailed: true
+    )
+}
+
 // Verifies that pausing the custom type blocks bridging via the custom type identifier.
 access(all)
 fun testPauseCustomTypeBlocksBridgeViaCustomType() {


### PR DESCRIPTION
## Summary

Fixes #203.

Mirrors the fix from #198 (FromEVM direction) for the ToEVM direction. When an EVM-native NFT has migrated from a legacy bridge-defined Cadence type to a custom Cadence type, pausing the custom type did not prevent bridging via a bridge-defined token. The top-level `bridgeNFTToEVM` precondition checks pause status on `token.getType()` (the bridge-defined type), which is not paused. The call then routes to `handleUpdatedBridgedNFTToEVM`, which burns the bridge-defined NFT and releases the ERC721 with no re-check on the custom type's pause status.

## Fix

Added a pause check on `updatedCadenceAssociation` (the resolved custom type) inside `handleUpdatedBridgedNFTToEVM`, immediately after it is resolved and before the burn and transfer.

## Test plan

- [x] Existing Cadence tests pass (`make cdc-test`)
- [x] `testPauseCustomTypeBlocksBridgeToEVMViaBridgeDefinedType` — regression test confirming that pausing the custom type now blocks the ToEVM path for bridge-defined NFTs
- [x] Verify that bridging via the bridge-defined type still works when the custom type is not paused