### PR TITLE
Replace opaque force-unwraps with descriptive panics and add FT symbol fallback

### DIFF
--- a/cadence/contracts/bridge/FlowEVMBridge.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridge.cdc
@@ -1091,10 +1091,9 @@ contract FlowEVMBridge : IFlowEVMNFTBridge, IFlowEVMTokenBridge {
         // storage cost was already accounted for when the NFT was escrowed on the ToEVM path. Unlocking reduces
         // bridge storage rather than increasing it, so no new fee is warranted.
         // Cadence-native NFTs must be in escrow, so unlock & return
-        return <-FlowEVMBridgeNFTEscrow.unlockNFT(
-            type: type,
-            id: FlowEVMBridgeNFTEscrow.getLockedCadenceID(type: type, evmID: id)!
-        )
+        let lockedCadenceID = FlowEVMBridgeNFTEscrow.getLockedCadenceID(type: type, evmID: id)
+            ?? panic("NFT of type \(type.identifier) with EVM ID \(id) is not in escrow — cannot bridge from EVM")
+        return <-FlowEVMBridgeNFTEscrow.unlockNFT(type: type, id: lockedCadenceID)
     }
 
     /// Handler to move registered cross-VM EVM-native NFTs from EVM

--- a/cadence/contracts/bridge/FlowEVMBridgeUtils.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeUtils.cdc
@@ -429,6 +429,10 @@ contract FlowEVMBridgeUtils {
                     let serializedDisplay = SerializeMetadata.serializeFTDisplay(ftDisplay!)
                     contractURI = "data:application/json;utf8,{".concat(serializedDisplay).concat("}")
                 }
+                // Derive a symbol from the name if no metadata view provided one
+                if symbol == nil {
+                    symbol = SerializeMetadata.deriveSymbol(fromString: name)
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Two small defensive improvements identified during a security review.

### Fix 1: Descriptive panic for missing escrow in `handleCadenceNativeCrossVMNFTFromEVM`

`FlowEVMBridge.cdc` — the `getLockedCadenceID` force-unwrap (`!`) in `handleCadenceNativeCrossVMNFTFromEVM` produces an opaque runtime panic with no context if a Cadence-native NFT is not found in escrow (e.g. due to state desync). Replaced with a nil-coalescing `?? panic(...)` that includes the type identifier and EVM ID to make failures easier to diagnose.

### Fix 2: FT symbol derivation fallback in `getCadenceOnboardingValues`

`FlowEVMBridgeUtils.cdc` — FTs that implement neither `EVMBridgedMetadata` nor `FTDisplay` left `symbol` as `nil`, then hit a `symbol!` force-unwrap, panicking instead of proceeding. NFTs already had a `SerializeMetadata.deriveSymbol(fromString: name)` fallback; this fix adds the equivalent for FTs.

## Test plan

- [x] Existing Cadence tests pass (`make cdc-test`)
- [x] No behavioral changes for the happy path — both changes only affect error/fallback code paths