### PR TITLE
Fix Cadence parse error in FlowEVMBridgeCustomAssociations precondition message

### DIFF
--- a/cadence/contracts/bridge/FlowEVMBridgeCustomAssociations.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeCustomAssociations.cdc
@@ -128,7 +128,7 @@ access(all) contract FlowEVMBridgeCustomAssociations {
             type.isSubtype(of: Type<@{NonFungibleToken.NFT}>()):
             "Only NFT cross-VM associations are currently supported but \(type.identifier) is not an NFT implementation"
             self.associationsByEVMAddress[evmContractAddress.toString()] == nil:
-            "EVM Address \(evmContractAddress.toString()) already has a custom association with \(self.associationsByEVMAddress[evmContractAddress.toString()]?.identifier ?? \"unknown type\")"
+            "EVM Address \(evmContractAddress.toString()) already has a custom association"
             fulfillmentMinter?.check() ?? true:
             "The NFTFulfillmentMinter Capability issued from \(fulfillmentMinter!.address.toString()) is invalid. Ensure the Capability is properly issued and active."
         }

--- a/cadence/contracts/bridge/FlowEVMBridgeCustomAssociations.cdc
+++ b/cadence/contracts/bridge/FlowEVMBridgeCustomAssociations.cdc
@@ -128,7 +128,7 @@ access(all) contract FlowEVMBridgeCustomAssociations {
             type.isSubtype(of: Type<@{NonFungibleToken.NFT}>()):
             "Only NFT cross-VM associations are currently supported but \(type.identifier) is not an NFT implementation"
             self.associationsByEVMAddress[evmContractAddress.toString()] == nil:
-            "EVM Address \(evmContractAddress.toString()) already has a custom association"
+            "EVM Address \(evmContractAddress.toString()) already has a custom association with \(self.associationsByEVMAddress[evmContractAddress.toString()]!.identifier)"
             fulfillmentMinter?.check() ?? true:
             "The NFTFulfillmentMinter Capability issued from \(fulfillmentMinter!.address.toString()) is invalid. Ensure the Capability is properly issued and active."
         }


### PR DESCRIPTION
## Summary

- Simplifies the precondition error message in `saveCustomAssociation` (line 131) to fix a parse error on testnet
- The previous message used `??` with escaped quotes inside string interpolation, which is not supported by the Cadence version running on testnet (though it passes on the local emulator)

## Root Cause

The Cadence version on testnet is older than the one used by the local emulator, causing a syntax that works in tests to fail on deployment.

**Before:**
```cadence
"EVM Address \(evmContractAddress.toString()) already has a custom association with \(self.associationsByEVMAddress[evmContractAddress.toString()]?.identifier ?? \"unknown type\")"
```

**After:**
```cadence
"EVM Address \(evmContractAddress.toString()) already has a custom association with \(self.associationsByEVMAddress[evmContractAddress.toString()]!.identifier)"
```

## Test plan
- [ ] Verify contract deploys successfully to testnet after merge