### PR TITLE
Update `EVM` dependency source from `testnet` to `mainnet`

### DIFF
--- a/flow.json
+++ b/flow.json
@@ -312,9 +312,9 @@
 			}
 		},
 		"EVM": {
-			"source": "testnet://8c5303eaa26202d6.EVM",
+			"source": "mainnet://e467b9dd11fa00df.EVM",
 			"hash": "02fdf06350d1aa9eaff70bb355968e46160a226ded80daf229330e7a1d8d8c2c",
-			"block_height": 315529260,
+			"block_height": 150781674,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "e467b9dd11fa00df",


### PR DESCRIPTION
## Description

This was temporarily changed to `testnet`, in https://github.com/onflow/flow-evm-bridge/pull/207/changes/f8c0d1b88e0949fdb1041eeddacbb4462bea9286, to unblock https://github.com/onflow/flow-evm-bridge/pull/207, while the `EVM` contract had not yet being updated on `mainnet`.

______

For contributor use:

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 