### PR TITLE
Escape JSON special characters in Serialize.tryToJSONString

### DIFF
--- a/cadence/contracts/utils/Serialize.cdc
+++ b/cadence/contracts/utils/Serialize.cdc
@@ -27,11 +27,11 @@ contract Serialize {
             case Type<Never?>():
                 return "\"nil\""
             case Type<String>():
-                return String.join(["\"", value as! String, "\"" ], separator: "")
+                return String.join(["\"", self.escapeJSONString(value as! String), "\"" ], separator: "")
             case Type<String?>():
-                return String.join(["\"", value as? String ?? "nil", "\"" ], separator: "")
+                return String.join(["\"", self.escapeJSONString(value as? String ?? "nil"), "\"" ], separator: "")
             case Type<Character>():
-                return String.join(["\"", (value as! Character).toString(), "\"" ], separator: "")
+                return String.join(["\"", self.escapeJSONString((value as! Character).toString()), "\"" ], separator: "")
             case Type<Bool>():
                 return String.join(["\"", value as! Bool ? "true" : "false", "\"" ], separator: "")
             case Type<Address>():
@@ -83,6 +83,59 @@ contract Serialize {
             default:
                 return nil
         }
+    }
+
+    /// Escapes a string for inclusion in a JSON string literal per RFC 8259 Section 7, escaping backslash,
+    /// double quote, and control characters U+0000 through U+001F. All other characters, including multi-byte
+    /// UTF-8 sequences, pass through unchanged.
+    ///
+    access(all)
+    fun escapeJSONString(_ str: String): String {
+        let bytes = str.utf8
+        // Fast path: return unchanged if nothing needs escaping (the common case)
+        var needsEscaping = false
+        for b in bytes {
+            if b == 0x22 || b == 0x5C || b < 0x20 {
+                needsEscaping = true
+                break
+            }
+        }
+        if !needsEscaping {
+            return str
+        }
+
+        let out: [UInt8] = []
+        for b in bytes {
+            switch b {
+                case 0x22:
+                    out.appendAll([0x5C, 0x22]) // \"
+                case 0x5C:
+                    out.appendAll([0x5C, 0x5C]) // \\
+                case 0x08:
+                    out.appendAll([0x5C, 0x62]) // \b
+                case 0x09:
+                    out.appendAll([0x5C, 0x74]) // \t
+                case 0x0A:
+                    out.appendAll([0x5C, 0x6E]) // \n
+                case 0x0C:
+                    out.appendAll([0x5C, 0x66]) // \f
+                case 0x0D:
+                    out.appendAll([0x5C, 0x72]) // \r
+                default:
+                    if b < 0x20 {
+                        // Escape remaining control characters as \u00XX with lowercase hex digits
+                        let low = b % 16
+                        out.appendAll([0x5C, 0x75, 0x30, 0x30]) // \u00
+                        out.append(b < 0x10 ? 0x30 : 0x31) // '0' or '1'
+                        out.append(low < 10 ? 0x30 + low : 0x57 + low) // '0'-'9' or 'a'-'f'
+                    } else {
+                        // All other bytes pass through, including multi-byte UTF-8 sequences (>= 0x80)
+                        out.append(b)
+                    }
+            }
+        }
+        return String.fromUTF8(out)
+            ?? panic("Serialize.escapeJSONString: failed to re-encode escaped UTF-8 bytes")
     }
 
     /// Returns a serialized representation of the given array or nil if the value is not serializable

--- a/cadence/tests/serialize_metadata_tests.cdc
+++ b/cadence/tests/serialize_metadata_tests.cdc
@@ -78,6 +78,74 @@ fun testSerializeNFTSucceeds() {
     Test.assertEqual(true, serializedMetadata == expectedPrefix.concat(altSuffix1) || serializedMetadata == expectedPrefix.concat(altSuffix2))
 }
 
+// Regression test for https://github.com/onflow/flow-evm-bridge/issues/213 - JSON special characters in
+// NFT metadata must be escaped so the serialized data URI remains parseable JSON
+access(all)
+fun testSerializeNFTWithSpecialCharsSucceeds() {
+    // setup_collection is idempotent, so re-running for alice is safe
+    let setupResult = executeTransaction(
+        "../transactions/example-assets/example-nft/setup_collection.cdc",
+        [],
+        alice
+    )
+    Test.expect(setupResult, Test.beSucceeded())
+
+    // capture pre-existing ids so the newly minted id can be identified
+    let idsBeforeResult = executeScript(
+        "../scripts/nft/get_ids.cdc",
+        [alice.address, "cadenceExampleNFTCollection"]
+    )
+    Test.expect(idsBeforeResult, Test.beSucceeded())
+    let idsBefore = idsBeforeResult.returnValue! as! [UInt64]
+
+    // name & multi-line description contain quotes, a newline & a tab
+    let mintResult = executeTransaction(
+        "../transactions/example-assets/example-nft/mint_nft.cdc",
+        [
+            alice.address,
+            "Example \"Special\" NFT",
+            "First line\nSecond line with a\ttab and \"quotes\"",
+            "https://flow.com/examplenft.jpg",
+            [], [], []
+        ],
+        admin
+    )
+    Test.expect(mintResult, Test.beSucceeded())
+
+    let heightResult = executeScript(
+        "./scripts/get_block_height.cdc",
+        []
+    )
+    let heightString = (heightResult.returnValue! as! UInt64).toString()
+
+    let idsAfterResult = executeScript(
+        "../scripts/nft/get_ids.cdc",
+        [alice.address, "cadenceExampleNFTCollection"]
+    )
+    Test.expect(idsAfterResult, Test.beSucceeded())
+    let idsAfter = idsAfterResult.returnValue! as! [UInt64]
+    var newID: UInt64 = 0
+    for id in idsAfter {
+        if !idsBefore.contains(id) {
+            newID = id
+        }
+    }
+
+    // Cadence dictionaries are not ordered by insertion order, so we need to check for both possible orderings
+    let expectedPrefix = "data:application/json;utf8,{\"name\": \"Example \\\"Special\\\" NFT\", \"description\": \"First line\\nSecond line with a\\ttab and \\\"quotes\\\"\", \"image\": \"https://flow.com/examplenft.jpg\", \"external_url\": \"https://example-nft.onflow.org\", "
+    let altSuffix1 = "\"attributes\": [{\"trait_type\": \"mintedBlock\", \"value\": \"\(heightString)\"}, {\"trait_type\": \"foo\", \"value\": \"bar\"}]}"
+    let altSuffix2 = "\"attributes\": [{\"trait_type\": \"foo\", \"value\": \"bar\"}, {\"trait_type\": \"mintedBlock\", \"value\": \"\(heightString)\"}]}"
+
+    let serializeMetadataResult = executeScript(
+        "../scripts/serialize/serialize_nft.cdc",
+        [alice.address, "cadenceExampleNFTCollection", newID]
+    )
+    Test.expect(serializeMetadataResult, Test.beSucceeded())
+
+    let serializedMetadata = serializeMetadataResult.returnValue! as! String
+    Test.assertEqual(true, serializedMetadata == "\(expectedPrefix)\(altSuffix1)" || serializedMetadata == "\(expectedPrefix)\(altSuffix2)")
+}
+
 // Returns nil when no displays are provided
 access(all)
 fun testSerializeNilDisplaysReturnsNil() {

--- a/cadence/tests/serialize_tests.cdc
+++ b/cadence/tests/serialize_tests.cdc
@@ -167,6 +167,111 @@ fun testCharacterTryToJSONStringSucceeds() {
 }
 
 access(all)
+fun testStringWithQuotesTryToJSONStringSucceeds() {
+    // input chars: say "hello" -> output chars: "say \"hello\""
+    let str = "say \"hello\""
+
+    let expected = "\"say \\\"hello\\\"\""
+
+    var actual = Serialize.tryToJSONString(str)
+    Test.assertEqual(expected, actual!)
+}
+
+access(all)
+fun testStringWithBackslashTryToJSONStringSucceeds() {
+    // input chars: back\slash -> output chars: "back\\slash"
+    let str = "back\\slash"
+
+    let expected = "\"back\\\\slash\""
+
+    var actual = Serialize.tryToJSONString(str)
+    Test.assertEqual(expected, actual!)
+}
+
+access(all)
+fun testStringWithWhitespaceControlsTryToJSONStringSucceeds() {
+    // newline, carriage return & tab -> \n \r \t escape sequences
+    let str = "line1\nline2\rline3\tend"
+
+    let expected = "\"line1\\nline2\\rline3\\tend\""
+
+    var actual = Serialize.tryToJSONString(str)
+    Test.assertEqual(expected, actual!)
+}
+
+access(all)
+fun testStringWithBackspaceAndFormFeedTryToJSONStringSucceeds() {
+    // backspace (U+0008) & form feed (U+000C) -> \b \f escape sequences
+    let str = "a\u{8}b\u{c}c"
+
+    let expected = "\"a\\bb\\fc\""
+
+    var actual = Serialize.tryToJSONString(str)
+    Test.assertEqual(expected, actual!)
+}
+
+access(all)
+fun testStringWithControlCharsTryToJSONStringSucceeds() {
+    // U+0001 & U+001F have no shorthand escapes -> \u00XX with lowercase hex
+    let str = "a\u{1}b\u{1f}c"
+
+    let expected = "\"a\\u0001b\\u001fc\""
+
+    var actual = Serialize.tryToJSONString(str)
+    Test.assertEqual(expected, actual!)
+}
+
+access(all)
+fun testStringWithUnicodeTryToJSONStringSucceeds() {
+    // multi-byte UTF-8 characters must pass through unmodified: é (U+00E9), ☕ (U+2615), 😀 (U+1F600)
+    let str = "Caf\u{e9} \u{2615} \u{1f600}"
+
+    let expected = "\"Caf\u{e9} \u{2615} \u{1f600}\""
+
+    var actual = Serialize.tryToJSONString(str)
+    Test.assertEqual(expected, actual!)
+}
+
+access(all)
+fun testOptionalStringWithSpecialCharsTryToJSONStringSucceeds() {
+    let strOpt: String? = "opt\n\"quoted\""
+
+    let expected = "\"opt\\n\\\"quoted\\\"\""
+
+    var actual = Serialize.tryToJSONString(strOpt)
+    Test.assertEqual(expected, actual!)
+}
+
+access(all)
+fun testCharacterWithSpecialCharTryToJSONStringSucceeds() {
+    let newline: Character = "\n"
+    let quote: Character = "\""
+
+    var actual = Serialize.tryToJSONString(newline)
+    Test.assertEqual("\"\\n\"", actual!)
+
+    actual = Serialize.tryToJSONString(quote)
+    Test.assertEqual("\"\\\"\"", actual!)
+}
+
+access(all)
+fun testDictWithSpecialCharKeyToJSONStringSucceeds() {
+    // single-entry dict avoids key-ordering nondeterminism
+    let dict: {String: AnyStruct} = {"key\nwith \"specials\"": "value\twith tab"}
+
+    let expected = "{\"key\\nwith \\\"specials\\\"\": \"value\\twith tab\"}"
+
+    var actual = Serialize.dictToJSONString(dict: dict, excludedNames: nil)
+    Test.assertEqual(expected, actual!)
+}
+
+access(all)
+fun testEscapeJSONStringWithoutSpecialCharsReturnsUnchanged() {
+    Test.assertEqual("Hello, World!", Serialize.escapeJSONString("Hello, World!"))
+    Test.assertEqual("", Serialize.escapeJSONString(""))
+}
+
+access(all)
 fun testUFix64TryToJSONStringSucceeds() {
     let uf64: UFix64 = UFix64.max
 


### PR DESCRIPTION
Closes: #213

## Description

Adds an `escapeJSONString` helper to `Serialize.cdc` that escapes `\`, `"`, and control characters (U+0000–U+001F) per RFC 8259 §7, and applies it in the `String`, `String?`, and `Character` cases of `tryToJSONString`. Dictionary keys in `dictToJSONString` are serialized through the same String case, so they are covered as well.

Escaping is a single pass over UTF-8 bytes with a fast path that returns the input unchanged when nothing needs escaping; multi-byte UTF-8 sequences pass through untouched.

Includes unit tests for all escape classes (quotes, backslash, `\n`/`\r`/`\t`, `\b`/`\f`, `\u00XX` control chars, multi-byte passthrough, dict keys) and a regression test serializing an NFT with quotes, a newline, and a tab in its name/description to a parseable JSON data URI.

______

For contributor use:

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-evm-bridge/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels